### PR TITLE
Rename webhook alert provider to generic

### DIFF
--- a/api/v1alpha1/provider_types.go
+++ b/api/v1alpha1/provider_types.go
@@ -24,7 +24,7 @@ import (
 // ProviderSpec defines the desired state of Provider
 type ProviderSpec struct {
 	// Type of provider
-	// +kubebuilder:validation:Enum=slack;discord;msteams;rocket;webhook
+	// +kubebuilder:validation:Enum=slack;discord;msteams;rocket;generic
 	// +required
 	Type string `json:"type"`
 
@@ -44,6 +44,14 @@ type ProviderSpec struct {
 	// +optional
 	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`
 }
+
+const (
+	GenericProvider string = "generic"
+	SlackProvider   string = "slack"
+	DiscordProvider string = "discord"
+	MSTeamsProvider string = "msteams"
+	RocketProvider  string = "rocket"
+)
 
 // ProviderStatus defines the observed state of Provider
 type ProviderStatus struct {

--- a/config/crd/bases/notification.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.fluxcd.io_providers.yaml
@@ -67,7 +67,7 @@ spec:
               - discord
               - msteams
               - rocket
-              - webhook
+              - generic
               type: string
             username:
               description: Bot username for this provider

--- a/docs/spec/v1alpha1/provider.md
+++ b/docs/spec/v1alpha1/provider.md
@@ -9,7 +9,7 @@ Spec:
 ```go
 type ProviderSpec struct {
 	// Type of provider
-	// +kubebuilder:validation:Enum=slack;discord;msteams;rocket;webhook
+	// +kubebuilder:validation:Enum=slack;discord;msteams;rocket;generic
 	// +required
 	Type string `json:"type"`
 
@@ -86,7 +86,7 @@ kubectl -n gitops-system create secret generic webhook-url \
 
 Note that the secret must contain an `address` field.
 
-The provider type can be: `slack`, `msteams`, `rocket`, `discord` or `webhook`. 
+The provider type can be: `slack`, `msteams`, `rocket`, `discord` or `generic`. 
 
-When type `webhook` is specified, the notification controller will post the
+When type `generic` is specified, the notification controller will post the
 incoming [event](event.md) in JSON format to the webhook address. 

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -18,6 +18,8 @@ package notifier
 
 import (
 	"fmt"
+
+	"github.com/fluxcd/notification-controller/api/v1alpha1"
 )
 
 type Factory struct {
@@ -42,15 +44,15 @@ func (f Factory) Notifier(provider string) (Interface, error) {
 	var n Interface
 	var err error
 	switch provider {
-	case "webhook":
+	case v1alpha1.GenericProvider:
 		n, err = NewForwarder(f.URL)
-	case "slack":
+	case v1alpha1.SlackProvider:
 		n, err = NewSlack(f.URL, f.Username, f.Channel)
-	case "discord":
+	case v1alpha1.DiscordProvider:
 		n, err = NewDiscord(f.URL, f.Username, f.Channel)
-	case "rocket":
+	case v1alpha1.RocketProvider:
 		n, err = NewRocket(f.URL, f.Username, f.Channel)
-	case "msteams":
+	case v1alpha1.MSTeamsProvider:
 		n, err = NewMSTeams(f.URL)
 	default:
 		err = fmt.Errorf("provider %s not supported", provider)


### PR DESCRIPTION
Changes:
- Add the alert provider types to API
- Rename `webhook` alert provider to `generic` 