### PR TITLE
Setup production logging

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -43,6 +43,7 @@ spec:
             path: /metrics
         args:
         - --enable-leader-election
+        - --log-level=debug
         - --log-json
         resources:
           limits:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/stretchr/testify v1.5.1
+	go.uber.org/zap v1.10.0
 	k8s.io/api v0.18.4
 	k8s.io/apimachinery v0.18.4
 	k8s.io/client-go v0.18.4


### PR DESCRIPTION
For production the log format is JSON, the timestamps format is ISO8601
and stack traces are logged when the level is set to debug.