### PR TITLE
Remove namespace scope from deployment

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -32,11 +32,6 @@ spec:
             name: http-webhook
           - containerPort: 8080
             name: http-prom
-        env:
-          - name: RUNTIME_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
         livenessProbe:
           httpGet:
             port: http-prom


### PR DESCRIPTION
To allow alert rules for resources outside of the controller's
namespace.