### PR TITLE
Publish ARM v7/v8 multi-arch image to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,21 +11,27 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup Kustomize
         uses: fluxcd/pkg//actions/kustomize@master
-      - name: Get version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION=sha-${GITHUB_SHA::8}
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF/refs\/tags\//}
+          fi
+          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=VERSION::${VERSION}
       - name: Generate release asset
         run: |
           mkdir -p config/release
           cp config/default/* config/release
           cd config/release
-          kustomize edit set image fluxcd/notification-controller=fluxcd/notification-controller:${{ steps.get_version.outputs.VERSION }}
+          kustomize edit set image fluxcd/notification-controller=fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
           kustomize build . > notification-controller.yaml
-      - name: Set up QEMU
+      - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all
-      - name: Set up Docker Buildx
+      - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
         with:
@@ -41,33 +47,50 @@ jobs:
         with:
           username: fluxcdbot
           password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
-      - name: Publish amd64 image
+      - name: Publish AMD64 image
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          tags: ghcr.io/fluxcd/notification-controller:${{ steps.get_version.outputs.VERSION }},docker.io/fluxcd/notification-controller:${{ steps.get_version.outputs.VERSION }}
-      - name: Publish arm64 image
+          tags: |
+            ghcr.io/fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
+            docker.io/fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.VERSION }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
+      - name: Publish ARM image
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/arm64
-          tags: ghcr.io/fluxcd/notification-controller-arm64:${{ steps.get_version.outputs.VERSION }}
+          platforms: linux/arm/v7,linux/arm64
+          tags: |
+            ghcr.io/fluxcd/notification-controller-arm64:${{ steps.prep.outputs.VERSION }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.VERSION }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
       - name: Check images
         run: |
-          docker buildx imagetools inspect docker.io/fluxcd/notification-controller:${{ steps.get_version.outputs.VERSION }}
-          docker buildx imagetools inspect ghcr.io/fluxcd/notification-controller:${{ steps.get_version.outputs.VERSION }}
-          docker buildx imagetools inspect ghcr.io/fluxcd/notification-controller-arm64:${{ steps.get_version.outputs.VERSION }}
-          docker pull docker.io/fluxcd/notification-controller:${{ steps.get_version.outputs.VERSION }}
-          docker pull ghcr.io/fluxcd/notification-controller:${{ steps.get_version.outputs.VERSION }}
-          docker pull ghcr.io/fluxcd/notification-controller-arm64:${{ steps.get_version.outputs.VERSION }}
+          docker buildx imagetools inspect docker.io/fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
+          docker buildx imagetools inspect ghcr.io/fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
+          docker buildx imagetools inspect ghcr.io/fluxcd/notification-controller-arm64:${{ steps.prep.outputs.VERSION }}
+          docker pull docker.io/fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
+          docker pull ghcr.io/fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
       - name: Create release
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         id: create_release
         uses: actions/create-release@latest
         env:
@@ -80,6 +103,7 @@ jobs:
           body: |
             [CHANGELOG](https://github.com/fluxcd/notification-controller/blob/master/CHANGELOG.md)
       - name: Upload artifacts
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
Changes:
- push multi-arch ARM image to `ghcr.io/fluxcd/notification-controller-arm64` for both `linux/arm/v7` and `linux/arm64`
- add opencontainers labels

For testing on ARM v7/v8:

```
docker run -it ghcr.io/fluxcd/notification-controller-arm64:e8659059
```

Tested by Alex Ellis on Raspberry PI 4.19.75-v71+ 🏅 