### PR TITLE
Change code to use subgroup in gitlab

### DIFF
--- a/internal/notifier/util.go
+++ b/internal/notifier/util.go
@@ -32,14 +32,9 @@ func parseGitAddress(s string) (string, string, error) {
 		return "", "", nil
 	}
 
-	path := strings.TrimLeft(u.Path, "/")
-	comp := strings.Split(path, "/")
-	if len(comp) != 2 {
-		return "", "", fmt.Errorf("Incorrectly formatted git address: %v", s)
-	}
-
+	id := strings.TrimLeft(u.Path, "/")
+	id = strings.TrimSuffix(id, ".git")
 	host := fmt.Sprintf("https://%s", u.Host)
-	id := comp[0] + "/" + strings.TrimSuffix(comp[1], ".git")
 	return host, id, nil
 }
 

--- a/internal/notifier/util_test.go
+++ b/internal/notifier/util_test.go
@@ -95,3 +95,11 @@ func TestUtil_ParseGitSshWithProtocol(t *testing.T) {
 	require.Equal(t, "https://github.com", host)
 	require.Equal(t, "stefanprodan/podinfo", id)
 }
+
+func TestUtil_ParseGitHttpWithSubgroup(t *testing.T) {
+	addr := "https://gitlab.com/foo/bar/foo.git"
+	host, id, err := parseGitAddress(addr)
+	require.NoError(t, err)
+	require.Equal(t, "https://gitlab.com", host)
+	require.Equal(t, "foo/bar/foo", id)
+}


### PR DESCRIPTION
When I use the subgroup of gitlab I get an error "Incorrectly formatted git address"
the id on gitlab can use more than two block
I changed the code to be able to handle two or more blocks in the ID
Can you tell me if this is right for you?