### PR TITLE
Send notification header identify requests as coming from the notification component.

### DIFF
--- a/internal/notifier/bitbucket.go
+++ b/internal/notifier/bitbucket.go
@@ -25,12 +25,14 @@ import (
 	"github.com/ktrysmt/go-bitbucket"
 )
 
+// Bitbucket is a Bitbucket Server notifier.
 type Bitbucket struct {
 	Owner  string
 	Repo   string
 	Client *bitbucket.Client
 }
 
+// NewBitbucket creates and returns a new Bitbucket notifier.
 func NewBitbucket(addr string, token string) (*Bitbucket, error) {
 	if len(token) == 0 {
 		return nil, errors.New("bitbucket token cannot be empty")

--- a/internal/notifier/client_test.go
+++ b/internal/notifier/client_test.go
@@ -42,7 +42,6 @@ func Test_postMessage(t *testing.T) {
 		require.Equal(t, "success", payload["status"])
 	}))
 	defer ts.Close()
-
 	err := postMessage(ts.URL, "", map[string]string{"status": "success"})
 	require.NoError(t, err)
 }

--- a/internal/notifier/forwarder_test.go
+++ b/internal/notifier/forwarder_test.go
@@ -33,6 +33,7 @@ func TestForwarder_Post(t *testing.T) {
 		b, err := ioutil.ReadAll(r.Body)
 		require.NoError(t, err)
 
+		require.Equal(t, "source-controller", r.Header.Get("gotk-component"))
 		var payload = recorder.Event{}
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)

--- a/internal/notifier/slack_test.go
+++ b/internal/notifier/slack_test.go
@@ -44,7 +44,6 @@ func TestSlack_Post(t *testing.T) {
 
 	err = slack.Post(testEvent())
 	require.NoError(t, err)
-
 }
 
 func TestSlack_PostUpdate(t *testing.T) {


### PR DESCRIPTION
Add support for sending a Notification-Controller header from the forwarder notifier.

This means that it can be identified in upstream requests.