### PR TITLE
Fix "Notification API reference" title

### DIFF
--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -1,4 +1,4 @@
-<h1>Kustomize API reference</h1>
+<h1>Notification API reference</h1>
 <p>Packages:</p>
 <ul class="simple">
 <li>

--- a/hack/api-docs/template/pkg.tpl
+++ b/hack/api-docs/template/pkg.tpl
@@ -1,5 +1,5 @@
 {{ define "packages" }}
-    <h1>Kustomize API reference</h1>
+    <h1>Notification API reference</h1>
 
     {{ with .packages}}
         <p>Packages:</p>


### PR DESCRIPTION
The title of the Notification API reference reads "Kustomize API reference".
Seems obvious where the template was copied from ;-)