### PR TITLE
Share flux2 maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,7 +2,7 @@ The maintainers are generally available in Slack at
 https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages/CLAJ40HV3)
 (obtain an invitation at https://slack.cncf.io/).
 
-In alphabetical order:
+This project shares maintainers from the main Flux v2 git repository,
+as listed in
 
-Philip Laine, Xenit <philip.laine@xenit.se> (github: @phillebaba, slack: phillebaba)
-Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)
+    https://github.com/fluxcd/flux2/blob/main/MAINTAINERS


### PR DESCRIPTION
See https://github.com/fluxcd/flux2/discussions/515.
