### PR TITLE
Add alert summary to notification metadata

### DIFF
--- a/api/v1beta1/alert_types.go
+++ b/api/v1beta1/alert_types.go
@@ -38,6 +38,10 @@ type AlertSpec struct {
 	// +required
 	EventSources []CrossNamespaceObjectReference `json:"eventSources"`
 
+	// Short description of the impact and affected cluster.
+	// +optional
+	Summary string `json:"summary,omitempty"`
+
 	// This flag tells the controller to suspend subsequent events dispatching.
 	// Defaults to false.
 	// +optional

--- a/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
@@ -96,6 +96,9 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+              summary:
+                description: Short description of the impact and affected cluster.
+                type: string
               suspend:
                 description: This flag tells the controller to suspend subsequent
                   events dispatching. Defaults to false.

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -113,6 +113,18 @@ If set to &lsquo;info&rsquo; no events will be filtered.</p>
 </tr>
 <tr>
 <td>
+<code>summary</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Short description of the impact and affected cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>suspend</code><br>
 <em>
 bool
@@ -487,6 +499,18 @@ If set to &lsquo;info&rsquo; no events will be filtered.</p>
 </td>
 <td>
 <p>Filter events based on the involved objects</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>summary</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Short description of the impact and affected cluster.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta1/alert.md
+++ b/docs/spec/v1beta1/alert.md
@@ -21,6 +21,10 @@ type AlertSpec struct {
 	// +required
 	EventSources []CrossNamespaceObjectReference `json:"eventSources"`
 
+	// Short description of the impact and affected cluster.
+	// +optional
+	Summary string `json:"summary,omitempty"`
+
 	// This flag tells the controller to suspend subsequent events dispatching.
 	// Defaults to false.
 	// +optional
@@ -93,3 +97,21 @@ spec:
 ```
 
 If you don't specify an event source namespace, the alert namespace will be used.
+
+You can add a summary to describe the impact of an event:
+
+```yaml
+apiVersion: notification.toolkit.fluxcd.io/v1beta1
+kind: Alert
+metadata:
+  name: ingress
+  namespace: nginx
+spec:
+  summary: "Ingress traffic affected in production (us-west-2)"
+  providerRef: 
+    name: on-call-slack
+  eventSeverity: error
+  eventSources:
+    - kind: HelmRelease
+      name: nginx-ingress
+```


### PR DESCRIPTION
Changes:
- Add summary (optional field) to Alert API 
- Add alert summary to notification metadata 

Example:

```yaml
apiVersion: notification.toolkit.fluxcd.io/v1beta1
kind: Alert
metadata:
  name: ingress
  namespace: nginx
spec:
  summary: "Ingress traffic affected in production (us-west-2)"
  providerRef: 
    name: on-call-slack
  eventSeverity: error
  eventSources:
    - kind: HelmRelease
      name: nginx-ingress
```

Fix: #94