### PR TITLE
Add hint about used "address" data key to the Provider CRD's SecretRef

### DIFF
--- a/api/v1beta1/provider_types.go
+++ b/api/v1beta1/provider_types.go
@@ -49,6 +49,7 @@ type ProviderSpec struct {
 	Proxy string `json:"proxy,omitempty"`
 
 	// Secret reference containing the provider webhook URL
+	// using "address" as data key
 	// +optional
 	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`
 }

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -59,6 +59,7 @@ spec:
                 type: string
               secretRef:
                 description: Secret reference containing the provider webhook URL
+                  using "address" as data key
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -282,7 +282,8 @@ Kubernetes core/v1.LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>Secret reference containing the provider webhook URL</p>
+<p>Secret reference containing the provider webhook URL
+using &ldquo;address&rdquo; as data key</p>
 </td>
 </tr>
 </table>
@@ -720,7 +721,8 @@ Kubernetes core/v1.LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>Secret reference containing the provider webhook URL</p>
+<p>Secret reference containing the provider webhook URL
+using &ldquo;address&rdquo; as data key</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
When using a K8s `Secret` to store the webhook URL, the "address" data key has to be used. I know that this is mentioned in the docs and samples already, but when reading the spec first, this hint should improve clarity.

Please note if I missed anything.