### PR TITLE
add service account to kustomize resources

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
     spec:
+      serviceAccountName: notification-controller
       terminationGracePeriodSeconds: 10
       containers:
       - name: manager

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -3,4 +3,5 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- service_account.yaml
 

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: notification-controller
+

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: notification-controller
+  namespace: notification-system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: notification-controller


### PR DESCRIPTION
This PR adds a notification-controller SA and binds the required existing roles to it, and tells the deployment to use it.
This will enable us to move away from the default SA which has very permissive roles bound to it by other components.
This is mentioned in this issue https://github.com/fluxcd/flux2/issues/243

I have a couple of queries with regards to this. In the `clusterRoleBinding` that binds the manager-role to the service account, I need to specify the namespace the service account is in. If I do this, I am presuming it will mean I have to make changes in manifestgen in flux2? Additionally, I should add a patch into the default Kustomization rather than hardcoding the namespace in the roleBinding resource?