### PR TITLE
Add object kind to messages

### DIFF
--- a/internal/notifier/discord.go
+++ b/internal/notifier/discord.go
@@ -91,7 +91,7 @@ func (s *Discord) Post(event recorder.Event) error {
 
 	a := SlackAttachment{
 		Color:      color,
-		AuthorName: fmt.Sprintf("%s/%s.%s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.InvolvedObject.Namespace),
+		AuthorName: fmt.Sprintf("%s/%s.%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.InvolvedObject.Namespace),
 		Text:       event.Message,
 		MrkdwnIn:   []string{"text"},
 		Fields:     sfields,

--- a/internal/notifier/discord.go
+++ b/internal/notifier/discord.go
@@ -91,7 +91,7 @@ func (s *Discord) Post(event recorder.Event) error {
 
 	a := SlackAttachment{
 		Color:      color,
-		AuthorName: fmt.Sprintf("%s.%s", event.InvolvedObject.Name, event.InvolvedObject.Namespace),
+		AuthorName: fmt.Sprintf("%s/%s.%s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.InvolvedObject.Namespace),
 		Text:       event.Message,
 		MrkdwnIn:   []string{"text"},
 		Fields:     sfields,

--- a/internal/notifier/discord_test.go
+++ b/internal/notifier/discord_test.go
@@ -36,7 +36,7 @@ func TestDiscord_Post(t *testing.T) {
 		var payload = SlackPayload{}
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
-		require.Equal(t, "GitRepository/webapp.gitops-system", payload.Attachments[0].AuthorName)
+		require.Equal(t, "gitrepository/webapp.gitops-system", payload.Attachments[0].AuthorName)
 		require.Equal(t, "metadata", payload.Attachments[0].Fields[0].Value)
 	}))
 	defer ts.Close()

--- a/internal/notifier/discord_test.go
+++ b/internal/notifier/discord_test.go
@@ -36,7 +36,7 @@ func TestDiscord_Post(t *testing.T) {
 		var payload = SlackPayload{}
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
-		require.Equal(t, "webapp.gitops-system", payload.Attachments[0].AuthorName)
+		require.Equal(t, "GitRepository/webapp.gitops-system", payload.Attachments[0].AuthorName)
 		require.Equal(t, "metadata", payload.Attachments[0].Fields[0].Value)
 	}))
 	defer ts.Close()

--- a/internal/notifier/rocket.go
+++ b/internal/notifier/rocket.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/fluxcd/pkg/recorder"
 )
@@ -79,7 +80,7 @@ func (s *Rocket) Post(event recorder.Event) error {
 
 	a := SlackAttachment{
 		Color:      color,
-		AuthorName: fmt.Sprintf("%s/%s.%s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.InvolvedObject.Namespace),
+		AuthorName: fmt.Sprintf("%s/%s.%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.InvolvedObject.Namespace),
 		Text:       event.Message,
 		MrkdwnIn:   []string{"text"},
 		Fields:     sfields,

--- a/internal/notifier/rocket.go
+++ b/internal/notifier/rocket.go
@@ -79,7 +79,7 @@ func (s *Rocket) Post(event recorder.Event) error {
 
 	a := SlackAttachment{
 		Color:      color,
-		AuthorName: fmt.Sprintf("%s.%s", event.InvolvedObject.Name, event.InvolvedObject.Namespace),
+		AuthorName: fmt.Sprintf("%s/%s.%s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.InvolvedObject.Namespace),
 		Text:       event.Message,
 		MrkdwnIn:   []string{"text"},
 		Fields:     sfields,

--- a/internal/notifier/rocket_test.go
+++ b/internal/notifier/rocket_test.go
@@ -34,7 +34,7 @@ func TestRocket_Post(t *testing.T) {
 		var payload = SlackPayload{}
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
-		require.Equal(t, "webapp.gitops-system", payload.Attachments[0].AuthorName)
+		require.Equal(t, "GitRepository/webapp.gitops-system", payload.Attachments[0].AuthorName)
 		require.Equal(t, "metadata", payload.Attachments[0].Fields[0].Value)
 	}))
 	defer ts.Close()

--- a/internal/notifier/rocket_test.go
+++ b/internal/notifier/rocket_test.go
@@ -34,7 +34,7 @@ func TestRocket_Post(t *testing.T) {
 		var payload = SlackPayload{}
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
-		require.Equal(t, "GitRepository/webapp.gitops-system", payload.Attachments[0].AuthorName)
+		require.Equal(t, "gitrepository/webapp.gitops-system", payload.Attachments[0].AuthorName)
 		require.Equal(t, "metadata", payload.Attachments[0].Fields[0].Value)
 	}))
 	defer ts.Close()

--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/fluxcd/pkg/recorder"
 )
@@ -103,7 +104,7 @@ func (s *Slack) Post(event recorder.Event) error {
 
 	a := SlackAttachment{
 		Color:      color,
-		AuthorName: fmt.Sprintf("%s/%s.%s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.InvolvedObject.Namespace),
+		AuthorName: fmt.Sprintf("%s/%s.%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.InvolvedObject.Namespace),
 		Text:       event.Message,
 		MrkdwnIn:   []string{"text"},
 		Fields:     sfields,

--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -103,7 +103,7 @@ func (s *Slack) Post(event recorder.Event) error {
 
 	a := SlackAttachment{
 		Color:      color,
-		AuthorName: fmt.Sprintf("%s.%s", event.InvolvedObject.Name, event.InvolvedObject.Namespace),
+		AuthorName: fmt.Sprintf("%s/%s.%s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.InvolvedObject.Namespace),
 		Text:       event.Message,
 		MrkdwnIn:   []string{"text"},
 		Fields:     sfields,

--- a/internal/notifier/slack_test.go
+++ b/internal/notifier/slack_test.go
@@ -34,7 +34,7 @@ func TestSlack_Post(t *testing.T) {
 		var payload = SlackPayload{}
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
-		require.Equal(t, "GitRepository/webapp.gitops-system", payload.Attachments[0].AuthorName)
+		require.Equal(t, "gitrepository/webapp.gitops-system", payload.Attachments[0].AuthorName)
 		require.Equal(t, "metadata", payload.Attachments[0].Fields[0].Value)
 	}))
 	defer ts.Close()

--- a/internal/notifier/slack_test.go
+++ b/internal/notifier/slack_test.go
@@ -34,7 +34,7 @@ func TestSlack_Post(t *testing.T) {
 		var payload = SlackPayload{}
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
-		require.Equal(t, "webapp.gitops-system", payload.Attachments[0].AuthorName)
+		require.Equal(t, "GitRepository/webapp.gitops-system", payload.Attachments[0].AuthorName)
 		require.Equal(t, "metadata", payload.Attachments[0].Fields[0].Value)
 	}))
 	defer ts.Close()

--- a/internal/notifier/teams.go
+++ b/internal/notifier/teams.go
@@ -78,7 +78,7 @@ func (s *MSTeams) Post(event recorder.Event) error {
 		})
 	}
 
-	objName := fmt.Sprintf("%s.%s", event.InvolvedObject.Name, event.InvolvedObject.Namespace)
+	objName := fmt.Sprintf("%s/%s.%s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.InvolvedObject.Namespace)
 	payload := MSTeamsPayload{
 		Type:       "MessageCard",
 		Context:    "http://schema.org/extensions",

--- a/internal/notifier/teams.go
+++ b/internal/notifier/teams.go
@@ -19,6 +19,7 @@ package notifier
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/fluxcd/pkg/recorder"
 )
@@ -78,7 +79,7 @@ func (s *MSTeams) Post(event recorder.Event) error {
 		})
 	}
 
-	objName := fmt.Sprintf("%s/%s.%s", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.InvolvedObject.Namespace)
+	objName := fmt.Sprintf("%s/%s.%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.InvolvedObject.Namespace)
 	payload := MSTeamsPayload{
 		Type:       "MessageCard",
 		Context:    "http://schema.org/extensions",

--- a/internal/notifier/teams_test.go
+++ b/internal/notifier/teams_test.go
@@ -34,7 +34,7 @@ func TestTeams_Post(t *testing.T) {
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
 
-		require.Equal(t, "webapp.gitops-system", payload.Sections[0].ActivitySubtitle)
+		require.Equal(t, "GitRepository/webapp.gitops-system", payload.Sections[0].ActivitySubtitle)
 		require.Equal(t, "metadata", payload.Sections[0].Facts[0].Value)
 	}))
 	defer ts.Close()

--- a/internal/notifier/teams_test.go
+++ b/internal/notifier/teams_test.go
@@ -34,7 +34,7 @@ func TestTeams_Post(t *testing.T) {
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
 
-		require.Equal(t, "GitRepository/webapp.gitops-system", payload.Sections[0].ActivitySubtitle)
+		require.Equal(t, "gitrepository/webapp.gitops-system", payload.Sections[0].ActivitySubtitle)
 		require.Equal(t, "metadata", payload.Sections[0].Facts[0].Value)
 	}))
 	defer ts.Close()


### PR DESCRIPTION
This pull request adds the object kind of the source of the notification to the message.
The format is `<kind>/<name>.<namespaces>`
Fixes #120 

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>