### PR TITLE
Allow ImageUpdateAutomations in object refs

### DIFF
--- a/api/v1beta1/reference_types.go
+++ b/api/v1beta1/reference_types.go
@@ -24,7 +24,7 @@ type CrossNamespaceObjectReference struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 
 	// Kind of the referent
-	// +kubebuilder:validation:Enum=Bucket;GitRepository;Kustomization;HelmRelease;HelmChart;HelmRepository;ImageRepository
+	// +kubebuilder:validation:Enum=Bucket;GitRepository;Kustomization;HelmRelease;HelmChart;HelmRepository;ImageRepository;ImageUpdateAutomation
 	// +required
 	Kind string `json:"kind,omitempty"`
 

--- a/api/v1beta1/reference_types.go
+++ b/api/v1beta1/reference_types.go
@@ -24,7 +24,7 @@ type CrossNamespaceObjectReference struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 
 	// Kind of the referent
-	// +kubebuilder:validation:Enum=Bucket;GitRepository;Kustomization;HelmRelease;HelmChart;HelmRepository;ImageRepository;ImageUpdateAutomation
+	// +kubebuilder:validation:Enum=Bucket;GitRepository;Kustomization;HelmRelease;HelmChart;HelmRepository;ImageRepository;ImagePolicy;ImageUpdateAutomation
 	// +required
 	Kind string `json:"kind,omitempty"`
 

--- a/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
@@ -74,6 +74,8 @@ spec:
                       - HelmChart
                       - HelmRepository
                       - ImageRepository
+                      - ImagePolicy
+                      - ImageUpdateAutomation
                       type: string
                     name:
                       description: Name of the referent

--- a/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
@@ -71,6 +71,8 @@ spec:
                       - HelmChart
                       - HelmRepository
                       - ImageRepository
+                      - ImagePolicy
+                      - ImageUpdateAutomation
                       type: string
                     name:
                       description: Name of the referent


### PR DESCRIPTION
This adds ImageUpdateAutomation and ImagePolicy as kinds allowed by cross-namespace
object references here. That has two effects:

 - ImageUpdateAutomation and ImagePolicy objects can be the source of events; and,
 - ImageUpdateAutomation and ImagePolicy objects can be the target of webhook
   triggers.

Of these, the first is certainly desirable (e.g,. now you can post a Slack message when automation fails).

The second may be useful for ImageUpdateAutomation, though automations will more usually be triggered by ImageRepository objects changing; but in any case, doesn't hurt. It is not useful for ImagePolicy objects, but on balance, I think it's better to keep the type generic than to make a special case for ImagePolicy.