### PR TITLE
Enable pprof endpoints on metrics server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fluxcd/notification-controller/api v0.7.1
 	github.com/fluxcd/pkg/apis/meta v0.7.0
 	github.com/fluxcd/pkg/recorder v0.0.6
-	github.com/fluxcd/pkg/runtime v0.8.0
+	github.com/fluxcd/pkg/runtime v0.8.1
 	github.com/fluxcd/source-controller/api v0.7.1
 	github.com/go-logr/logr v0.3.0
 	github.com/google/go-github/v32 v32.1.0

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/fluxcd/pkg/apis/meta v0.7.0 h1:5e8gm4OLqjuKWdrOIY5DEEsjcwzyJFK8rCDesJ
 github.com/fluxcd/pkg/apis/meta v0.7.0/go.mod h1:yHuY8kyGHYz22I0jQzqMMGCcHViuzC/WPdo9Gisk8Po=
 github.com/fluxcd/pkg/recorder v0.0.6 h1:me/n8syeeGXz50OXoPX3jgIj9AtinvhHdKT9Dy+MbHs=
 github.com/fluxcd/pkg/recorder v0.0.6/go.mod h1:IfQxfVRSNsWs3B0Yp5B6ObEWwKHILlAx8N7XkoDdhFg=
-github.com/fluxcd/pkg/runtime v0.8.0 h1:cnSBZJLcXlKgjXpFFFExu+4ZncIxmPgNIx+ErLcCLnA=
-github.com/fluxcd/pkg/runtime v0.8.0/go.mod h1:tQwEN+RESjJmtwSSv7I+6bkNM9raIXpGsCjruaIVX6A=
+github.com/fluxcd/pkg/runtime v0.8.1 h1:8UxNz7GeI/HC3U5tpNCfrjRx2V7UjUegQOwCsd+EWxk=
+github.com/fluxcd/pkg/runtime v0.8.1/go.mod h1:tQwEN+RESjJmtwSSv7I+6bkNM9raIXpGsCjruaIVX6A=
 github.com/fluxcd/source-controller/api v0.7.1 h1:GsiPhpApnt83H1TOA5aw/55N/oiMItaf+j9dVpvJedA=
 github.com/fluxcd/source-controller/api v0.7.1/go.mod h1:u2sdc/QDm0tzXHL7mZVj928hc3MMU+4mKCuAQg+94Bk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/fluxcd/pkg/runtime/client"
 	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/fluxcd/pkg/runtime/metrics"
+	"github.com/fluxcd/pkg/runtime/pprof"
 	"github.com/fluxcd/pkg/runtime/probes"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 
@@ -110,6 +111,7 @@ func main() {
 	}
 
 	probes.SetupChecks(mgr, setupLog)
+	pprof.SetupHandlers(mgr, setupLog)
 
 	if err = (&controllers.ProviderReconciler{
 		Client:          mgr.GetClient(),


### PR DESCRIPTION
Using the helper from `pkg/runtime/pprof`, which follows the suggestion
from controller-runtime to use `AddMetricsExtraHandler`.

Ref: https://github.com/fluxcd/flux2/issues/873