### PR TITLE
Fixing openssl oneliner to work on macOS and Linux

### DIFF
--- a/docs/spec/v1beta1/receiver.md
+++ b/docs/spec/v1beta1/receiver.md
@@ -129,7 +129,7 @@ The signature should be prefixed with the hash function(`sha1`, `sha256`, or `sh
 1. Generate hash signature using OpenSSL:
 
 ```sh
-echo -n '<request-body>' | openssl dgst -sha1 -hmac "<secret-key>"
+printf '<request-body>' | openssl dgst -sha1 -r -hmac "<secret-key>" | awk '{print $1}'
 ```
 
 You can use the flag `sha256` or `sha512` if you want a different hash function.


### PR DESCRIPTION
Running the following command works on macOS (`LibreSSL 2.8.3`) but prints polluted output on Linux (`OpenSSL 1.1.1i  8 Dec 2020`)

```bash
printf '{}' | openssl dgst -sha1 -hmac "<secret-key>"
(macOS)> c75d9c41825117acf1f7a80b366fa1d47caf6962
(linux)> (stdin)= c75d9c41825117acf1f7a80b366fa1d47caf6962
```

The coreutils format output, with `-r`, adds `*stdin` at the end, removing it with `awk` make it works on both environments.

```bash
printf '{}' | openssl dgst -sha1 -r -hmac "<secret-key>" | awk '{print $1}'
(macOS)> c75d9c41825117acf1f7a80b366fa1d47caf6962
(linux)> c75d9c41825117acf1f7a80b366fa1d47caf6962
```