### PR TITLE
Use numeric UID for user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ COPY --from=builder /workspace/notification-controller /usr/local/bin/
 # https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-RUN addgroup -S controller && adduser -S controller -G controller
+RUN addgroup -S controller && adduser -S controller -G controller -u 65533
 
-USER controller
+USER 65533
 
 ENTRYPOINT [ "/sbin/tini", "--", "notification-controller" ]


### PR DESCRIPTION
Hey guys!

This PR simply specifies the UID for the "controller" user created by `Dockerfile`, to satisfy Kubernetes PSPs which enforce non-root containers. Without this change, the pod won't start, with this error:

```
  Warning  Failed     12s (x4 over 26s)  kubelet            Error: container has runAsNonRoot and image has non-numeric user (controller), cannot verify user is non-root
```

(Note, a matching PR has been submitted for source-controller, at https://github.com/fluxcd/source-controller/pull/297

Cheers!
D