### PR TITLE
Refactor release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,6 @@ jobs:
           fi
           echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo ::set-output name=VERSION::${VERSION}
-      - name: Generate release asset
-        run: |
-          mkdir -p config/release
-          cp config/default/* config/release
-          cd config/release
-          kustomize edit set image fluxcd/notification-controller=fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
-          kustomize build . > notification-controller.yaml
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -71,27 +64,17 @@ jobs:
           docker buildx imagetools inspect ghcr.io/fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
           docker pull docker.io/fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
           docker pull ghcr.io/fluxcd/notification-controller:${{ steps.prep.outputs.VERSION }}
+      - name: Generate release manifests
+        run: |
+          mkdir -p config/release
+          kustomize build ./config/crd > ./config/release/notification-controller.crds.yaml
+          kustomize build ./config/manager > ./config/release/notification-controller.deployment.yaml
       - name: Create release
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-        id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
           prerelease: true
+          artifacts: "config/release/*.yaml"
+          artifactContentType: "text/plain"
           body: |
             [CHANGELOG](https://github.com/fluxcd/notification-controller/blob/main/CHANGELOG.md)
-      - name: Upload artifacts
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./config/release/notification-controller.yaml
-          asset_name: notification-controller.yaml
-          asset_content_type: text/plain
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changes:

- switch to [ncipollo/release-action](https://github.com/ncipollo/release-action) as GitHub has abandoned  https://github.com/actions/create-release/issues/119 and https://github.com/actions/upload-release-asset/issues/78
- add notification-controller CRDs and Deployment manifests to GitHub releases assets, this will allow us to use them as remote bases in flux2 instead of extracting them from the zip asset, ref: https://github.com/fluxcd/flux2/issues/918
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - https://github.com/fluxcd/notification-controller/releases/download/v0.9.0/notification-controller.crds.yaml
  - https://github.com/fluxcd/notification-controller/releases/download/v0.9.0/notification-controller.deployment.yaml
```
- drop the `notification-controller.yaml` asset, people can build their own with:
```sh
kustomize build https://github.com/fluxcd/notification-controller/config/default?ref=v0.8.1
```