### PR TITLE
Fix Azure Devops notifier issues

### DIFF
--- a/internal/notifier/github.go
+++ b/internal/notifier/github.go
@@ -96,7 +96,7 @@ func (g *GitHub) Post(event recorder.Event) error {
 	if err != nil {
 		return fmt.Errorf("could not list commit statuses: %v", err)
 	}
-	if duplicateStatus(statuses, status) {
+	if duplicateGithubStatus(statuses, status) {
 		return nil
 	}
 
@@ -121,7 +121,7 @@ func toGitHubState(severity string) (string, error) {
 
 // duplicateStatus return true if the latest status
 // with a matching context has the same state and description
-func duplicateStatus(statuses []*github.RepoStatus, status *github.RepoStatus) bool {
+func duplicateGithubStatus(statuses []*github.RepoStatus, status *github.RepoStatus) bool {
 	for _, s := range statuses {
 		if *s.Context == *status.Context {
 			if *s.State == *status.State && *s.Description == *status.Description {

--- a/internal/notifier/github_test.go
+++ b/internal/notifier/github_test.go
@@ -40,7 +40,7 @@ func TestNewGitHubEmptyToken(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestDuplicateState(t *testing.T) {
+func TestDuplicateGithubStatus(t *testing.T) {
 	assert := assert.New(t)
 
 	var tests = []struct {
@@ -56,7 +56,7 @@ func TestDuplicateState(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(test.dup, duplicateStatus(test.ss, test.s))
+		assert.Equal(test.dup, duplicateGithubStatus(test.ss, test.s))
 	}
 }
 

--- a/internal/notifier/util.go
+++ b/internal/notifier/util.go
@@ -32,9 +32,14 @@ func parseGitAddress(s string) (string, string, error) {
 		return "", "", nil
 	}
 
+	scheme := u.Scheme
+	if u.Scheme == "ssh" {
+		scheme = "https"
+	}
+
 	id := strings.TrimLeft(u.Path, "/")
 	id = strings.TrimSuffix(id, ".git")
-	host := fmt.Sprintf("https://%s", u.Host)
+	host := fmt.Sprintf("%s://%s", scheme, u.Host)
 	return host, id, nil
 }
 


### PR DESCRIPTION
This change contains general fixes to the Azure DevOps notifier to fix smaller usability issues.

* Respect schema set by the provider url
* Modify the Azure DevOps notifier to allow compatibility with running behind a proxy.
* Check existing commit statuses to avoid spamming the same status when reconciling.

Signed-off-by: Philip Laine <philip.laine@xenit.se>