### PR TITLE
Set leader election deadline to 30s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/fluxcd/notification-controller/api => ./api
 require (
 	github.com/fluxcd/notification-controller/api v0.10.0
 	github.com/fluxcd/pkg/apis/meta v0.8.0
-	github.com/fluxcd/pkg/runtime v0.9.0
+	github.com/fluxcd/pkg/runtime v0.10.1
 	github.com/go-logr/logr v0.3.0
 	github.com/google/go-github/v32 v32.1.0
 	github.com/hashicorp/go-retryablehttp v0.6.8

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fluxcd/pkg/apis/meta v0.8.0 h1:wqWpUsxhKHB1ZztcvOz+vnyhdKW9cWmjFp8Vci/XOdk=
 github.com/fluxcd/pkg/apis/meta v0.8.0/go.mod h1:yHuY8kyGHYz22I0jQzqMMGCcHViuzC/WPdo9Gisk8Po=
-github.com/fluxcd/pkg/runtime v0.9.0 h1:4ZnkyWg+MTEh6ne7E4DwS77nGsih7b5YscwVRIu+XfI=
-github.com/fluxcd/pkg/runtime v0.9.0/go.mod h1:JD0eZIn5xkTeHHQUWXSqJPIh/ecO0d0qrUKbSVHnpnw=
+github.com/fluxcd/pkg/runtime v0.10.1 h1:NV0pe6lFzodKBIz0dT3xkoR0wJnTCicXwM/v/d5T0+Y=
+github.com/fluxcd/pkg/runtime v0.10.1/go.mod h1:JD0eZIn5xkTeHHQUWXSqJPIh/ecO0d0qrUKbSVHnpnw=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=


### PR DESCRIPTION
This PR allows fine tuning the leader election with cmd args:

```
--enable-leader-election=true
--leader-election-release-on-cancel=true
--leader-election-lease-duration=35s
--leader-election-renew-deadline=30s
--leader-election-retry-period=5s
```

To make the leader election more tolerant to transient Kubernetes API outages, the renewal deadline was increased from 10s to 30s and the retry interval was bumped to 5 seconds.

Part of: https://github.com/fluxcd/pkg/issues/94