### PR TITLE
fix: use sha1 sum as value for key in bitbucket api requests

### DIFF
--- a/internal/notifier/bitbucket.go
+++ b/internal/notifier/bitbucket.go
@@ -85,6 +85,8 @@ func (b Bitbucket) Post(event events.Event) error {
 	}
 
 	name, desc := formatNameAndDescription(event)
+	// key has a limitation of 40 characters in bitbucket api
+	key := sha1String(name)
 
 	cmo := &bitbucket.CommitsOptions{
 		Owner:    b.Owner,
@@ -93,7 +95,7 @@ func (b Bitbucket) Post(event events.Event) error {
 	}
 	cso := &bitbucket.CommitStatusOptions{
 		State:       state,
-		Key:         name,
+		Key:         key,
 		Name:        name,
 		Description: desc,
 		Url:         "https://bitbucket.org",

--- a/internal/notifier/util.go
+++ b/internal/notifier/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"strings"
 	"unicode"
@@ -114,4 +115,9 @@ func isCommitStatus(meta map[string]string, status string) bool {
 		return true
 	}
 	return false
+}
+
+func sha1String(str string) string {
+	bs := []byte(str)
+	return fmt.Sprintf("%x", sha1.Sum(bs))
 }

--- a/internal/notifier/util_test.go
+++ b/internal/notifier/util_test.go
@@ -103,3 +103,9 @@ func TestUtil_ParseGitHttpWithSubgroup(t *testing.T) {
 	require.Equal(t, "https://gitlab.com", host)
 	require.Equal(t, "foo/bar/foo", id)
 }
+
+func TestUtil_Sha1String(t *testing.T) {
+	str := "kustomization/namespace-foo-and-service-bar"
+	s := sha1String(str)
+	require.Equal(t, "12ea142172e98435e16336acbbed8919610922c3", s)
+}


### PR DESCRIPTION
Fixes #173 

Suggestion is to use sha1 sum as value.

Signed-off-by: Mikael Bergemalm <mbergemalm@gmail.com>