### PR TITLE
Redact token from error log

### DIFF
--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -222,7 +224,9 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 
 			go func(n notifier.Interface, e events.Event) {
 				if err := n.Post(e); err != nil {
-					s.logger.Error(err, "failed to send notification",
+					redacted := strings.ReplaceAll(err.Error(), token, "*****")
+					redactedErr := errors.New(redacted)
+					s.logger.Error(redactedErr, "failed to send notification",
 						"reconciler kind", event.InvolvedObject.Kind,
 						"name", event.InvolvedObject.Name,
 						"namespace", event.InvolvedObject.Namespace)


### PR DESCRIPTION
Some errors like those from net/http will include the token value. We need to make sure that we redact the token value before logging as to not expose the value.

Fixes #160