### PR TITLE
Fix revision parsing when branch contains slash

### DIFF
--- a/internal/notifier/util.go
+++ b/internal/notifier/util.go
@@ -99,15 +99,14 @@ func splitCamelcase(src string) (entries []string) {
 
 func parseRevision(rev string) (string, error) {
 	comp := strings.Split(rev, "/")
-	if len(comp) != 2 {
+	if len(comp) < 2 {
 		return "", fmt.Errorf("Revision string format incorrect: %v", rev)
 	}
-
-	if comp[1] == "" {
+	sha := comp[len(comp)-1]
+	if sha == "" {
 		return "", fmt.Errorf("Commit Sha cannot be empty: %v", rev)
 	}
-
-	return comp[1], nil
+	return sha, nil
 }
 
 func isCommitStatus(meta map[string]string, status string) bool {

--- a/internal/notifier/util_test.go
+++ b/internal/notifier/util_test.go
@@ -44,16 +44,23 @@ func TestUtil_ParseRevision(t *testing.T) {
 	require.Equal(t, "a1afe267b54f38b46b487f6e938a6fd508278c07", rev)
 }
 
+func TestUtil_ParseRevisionNestedBranch(t *testing.T) {
+	revString := "environment/dev/a1afe267b54f38b46b487f6e938a6fd508278c07"
+	rev, err := parseRevision(revString)
+	require.NoError(t, err)
+	require.Equal(t, "a1afe267b54f38b46b487f6e938a6fd508278c07", rev)
+}
+
+func TestUtil_ParseRevisionOneComponents(t *testing.T) {
+	revString := "master"
+	_, err := parseRevision(revString)
+	require.EqualError(t, err, "Revision string format incorrect: master")
+}
+
 func TestUtil_ParseRevisionTooFewComponents(t *testing.T) {
 	revString := "master/"
 	_, err := parseRevision(revString)
-	require.Error(t, err)
-}
-
-func TestUtil_ParseRevisionTooManyComponents(t *testing.T) {
-	revString := "master/a1afe267b54f38b46b487f6e938a6fd508278c07/foo/bar"
-	_, err := parseRevision(revString)
-	require.Error(t, err)
+	require.EqualError(t, err, "Commit Sha cannot be empty: master/")
 }
 
 func TestUtil_ParseGitHttps(t *testing.T) {


### PR DESCRIPTION
This changes the parse revision logic to accept branches with slashes in them. Instead it will allow for infinite amount of slashes in the branch name and expect the last component to be the commit SHA.

Fixes #199 