### PR TITLE
Add cert pool to Slack provider requests

### DIFF
--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -54,7 +54,7 @@ func (f Factory) Notifier(provider string) (Interface, error) {
 	case v1beta1.GenericProvider:
 		n, err = NewForwarder(f.URL, f.ProxyURL, f.CertPool)
 	case v1beta1.SlackProvider:
-		n, err = NewSlack(f.URL, f.ProxyURL, f.Username, f.Channel)
+		n, err = NewSlack(f.URL, f.ProxyURL, f.CertPool, f.Username, f.Channel)
 	case v1beta1.DiscordProvider:
 		n, err = NewDiscord(f.URL, f.ProxyURL, f.Username, f.Channel)
 	case v1beta1.RocketProvider:

--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/url"
@@ -31,6 +32,7 @@ type Slack struct {
 	ProxyURL string
 	Username string
 	Channel  string
+	CertPool *x509.CertPool
 }
 
 // SlackPayload holds the channel and attachments
@@ -59,7 +61,7 @@ type SlackField struct {
 }
 
 // NewSlack validates the Slack URL and returns a Slack object
-func NewSlack(hookURL string, proxyURL string, username string, channel string) (*Slack, error) {
+func NewSlack(hookURL string, proxyURL string, certPool *x509.CertPool, username string, channel string) (*Slack, error) {
 	_, err := url.ParseRequestURI(hookURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Slack hook URL %s", hookURL)
@@ -74,6 +76,7 @@ func NewSlack(hookURL string, proxyURL string, username string, channel string) 
 		Username: username,
 		URL:      hookURL,
 		ProxyURL: proxyURL,
+		CertPool: certPool,
 	}, nil
 }
 
@@ -112,7 +115,7 @@ func (s *Slack) Post(event events.Event) error {
 
 	payload.Attachments = []SlackAttachment{a}
 
-	err := postMessage(s.URL, s.ProxyURL, nil, payload)
+	err := postMessage(s.URL, s.ProxyURL, s.CertPool, payload)
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}

--- a/internal/notifier/slack_test.go
+++ b/internal/notifier/slack_test.go
@@ -39,7 +39,7 @@ func TestSlack_Post(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	slack, err := NewSlack(ts.URL, "", "", "test")
+	slack, err := NewSlack(ts.URL, "", nil, "", "test")
 	require.NoError(t, err)
 
 	err = slack.Post(testEvent())
@@ -47,7 +47,7 @@ func TestSlack_Post(t *testing.T) {
 }
 
 func TestSlack_PostUpdate(t *testing.T) {
-	slack, err := NewSlack("http://localhost", "", "", "test")
+	slack, err := NewSlack("http://localhost", "", nil, "", "test")
 	require.NoError(t, err)
 
 	event := testEvent()


### PR DESCRIPTION
This change just brings the Slack provider inline with other providers which could be used with self hosted instances.

Fixes #203