### PR TITLE
Make slack channel optional

### DIFF
--- a/internal/notifier/client.go
+++ b/internal/notifier/client.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -87,8 +88,17 @@ func postMessage(address, proxy string, certPool *x509.CertPool, payload interfa
 	for _, o := range reqOpts {
 		o(req)
 	}
-	if _, err := httpClient.Do(req); err != nil {
+	resp, err := httpClient.Do(req)
+	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("unable to read response body, %s", err)
+		}
+		return fmt.Errorf("request not successful, %s", string(b))
 	}
 
 	return nil

--- a/internal/notifier/client.go
+++ b/internal/notifier/client.go
@@ -98,7 +98,7 @@ func postMessage(address, proxy string, certPool *x509.CertPool, payload interfa
 		if err != nil {
 			return fmt.Errorf("unable to read response body, %s", err)
 		}
-		return fmt.Errorf("request not successful, %s", string(b))
+		return fmt.Errorf("request failed with status code %d, %s", resp.StatusCode, string(b))
 	}
 
 	return nil

--- a/internal/notifier/client.go
+++ b/internal/notifier/client.go
@@ -93,7 +93,7 @@ func postMessage(address, proxy string, certPool *x509.CertPool, payload interfa
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusCreated {
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("unable to read response body, %s", err)

--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -18,7 +18,6 @@ package notifier
 
 import (
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -67,10 +66,6 @@ func NewSlack(hookURL string, proxyURL string, certPool *x509.CertPool, username
 		return nil, fmt.Errorf("invalid Slack hook URL %s", hookURL)
 	}
 
-	if channel == "" {
-		return nil, errors.New("empty Slack channel")
-	}
-
 	return &Slack{
 		Channel:  channel,
 		Username: username,
@@ -88,9 +83,13 @@ func (s *Slack) Post(event events.Event) error {
 	}
 
 	payload := SlackPayload{
-		Channel:  s.Channel,
 		Username: s.Username,
 	}
+
+	if s.Channel != "" {
+		payload.Channel = s.Channel
+	}
+
 	if payload.Username == "" {
 		payload.Username = event.ReportingController
 	}

--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -224,9 +224,12 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 
 			go func(n notifier.Interface, e events.Event) {
 				if err := n.Post(e); err != nil {
-					redacted := strings.ReplaceAll(err.Error(), token, "*****")
-					redactedErr := errors.New(redacted)
-					s.logger.Error(redactedErr, "failed to send notification",
+					if token != "" {
+						redacted := strings.ReplaceAll(err.Error(), token, "*****")
+						err = errors.New(redacted)
+					}
+
+					s.logger.Error(err, "failed to send notification",
 						"reconciler kind", event.InvolvedObject.Kind,
 						"name", event.InvolvedObject.Name,
 						"namespace", event.InvolvedObject.Namespace)


### PR DESCRIPTION
## Changes
- Makes slack channel optional
- Only redacts token from logs if it is present (to prevent distorting the error message)
- Checks status code of HTTP request and returns an error if not successful

Fixes: #200 

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>