### PR TITLE
Fix a few typos

### DIFF
--- a/docs/spec/v1beta1/receiver.md
+++ b/docs/spec/v1beta1/receiver.md
@@ -67,13 +67,13 @@ type ReceiverStatus struct {
 
 Considerations should be made when exposing the notification controller receiver
 to the public internet. Each request to the receiver endpoint will result in request
-to the Kuberentes API as the controller needs to fetch information about the receiver.
+to the Kubernetes API as the controller needs to fetch information about the receiver.
 The receiver endpoint may be protected with a token but it does not defend against a
 situation where a legitimate webhook source starts sending large amounts of requests,
 or the token is somehow leaked. This may result in unwanted consequences like the controller
-being rate limited by the Kuberentes API, degrading its functionality.
+being rate limited by the Kubernetes API, degrading its functionality.
 
-It is therefor a good idea to set rate limits on the ingress resource which exposes
+It is therefore a good idea to set rate limits on the ingress resource which exposes
 the receiver. If you are using ingress-nginx that can be done by [adding annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#rate-limiting).
 
 ## Example


### PR DESCRIPTION
"Therefor" is a word, but I don't think this is one of its uses

Also `Kuberentes` -> `Kubernetes`