### PR TITLE
providers/sentry: fix default HTTP Transport causing panic

### DIFF
--- a/internal/notifier/sentry.go
+++ b/internal/notifier/sentry.go
@@ -33,7 +33,7 @@ type Sentry struct {
 
 // NewSentry creates a Sentry client from the provided Data Source Name (DSN)
 func NewSentry(certPool *x509.CertPool, dsn string) (*Sentry, error) {
-	var tr *http.Transport
+	tr := &http.Transport{}
 	if certPool != nil {
 		tr = &http.Transport{
 			TLSClientConfig: &tls.Config{


### PR DESCRIPTION
With the current version, using the sentry provider, the notification controller panics when no custom certificates are set:

```
{"level":"info","ts":"2021-07-19T21:01:53.329Z","logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8080"}
{"level":"info","ts":"2021-07-19T21:01:53.331Z","logger":"setup","msg":"starting event server","addr":":9090"}
{"level":"info","ts":"2021-07-19T21:01:53.331Z","logger":"setup","msg":"starting webhook receiver server","addr":":9292"}
{"level":"info","ts":"2021-07-19T21:01:53.332Z","logger":"setup","msg":"starting manager"}
I0719 21:01:53.332684       7 leaderelection.go:243] attempting to acquire leader lease flux-system/notification-controller-leader-election...
{"level":"info","ts":"2021-07-19T21:01:53.332Z","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":"2021-07-19T21:01:59.028Z","logger":"event-server","msg":"Dispatching event: Latest image tag for 'beryju.org/authentik/server' resolved to: gh-master-1626710626","reconciler kind":"ImagePolicy","name":"authentik-gh-master","namespace":"flux-system"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x81d15f]

goroutine 312 [running]:
net/http.(*Transport).alternateRoundTripper(0x0, 0xc0006bbb00, 0xc0000ca420, 0xc0004a6d80)
	/usr/local/go/src/net/http/transport.go:487 +0x5f
net/http.knownRoundTripperImpl(0x1d74180, 0x0, 0xc0006bbb00, 0x203000)
	/usr/local/go/src/net/http/client.go:316 +0x10c
net/http.setRequestCancel(0xc0006bbb00, 0x1d74180, 0x0, 0xc03597f947ba9fc0, 0x88da93f5a, 0x2893d60, 0xc0004e8b30, 0x40e358)
	/usr/local/go/src/net/http/client.go:348 +0x9f
net/http.send(0xc0006bba00, 0x1d74180, 0x0, 0xc03597f947ba9fc0, 0x88da93f5a, 0x2893d60, 0xc00000e998, 0xc03597f947ba9fc0, 0x1, 0x0)
	/usr/local/go/src/net/http/client.go:250 +0x412
net/http.(*Client).send(0xc00051a6c0, 0xc0006bba00, 0xc03597f947ba9fc0, 0x88da93f5a, 0x2893d60, 0xc00000e998, 0x0, 0x1, 0xc00001bd01)
	/usr/local/go/src/net/http/client.go:176 +0xff
net/http.(*Client).do(0xc00051a6c0, 0xc0006bba00, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/http/client.go:718 +0x45f
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:586
github.com/getsentry/sentry-go.(*HTTPTransport).worker(0xc000517100)
	/go/pkg/mod/github.com/getsentry/sentry-go@v0.10.0/transport.go:386 +0x171
created by github.com/getsentry/sentry-go.(*HTTPTransport).Configure.func1
	/go/pkg/mod/github.com/getsentry/sentry-go@v0.10.0/transport.go:249 +0x3e
```

When I download the CA Certs and set them `certSecretRef`, everything works fine.