### PR TITLE
providers/sentry: add environment support

### DIFF
--- a/docs/spec/v1beta1/provider.md
+++ b/docs/spec/v1beta1/provider.md
@@ -226,7 +226,20 @@ kubectl create secret generic $SECRET_NAME \
 
 ### Sentry
 
-The sentry provider uses the `channel` field to specify which environment the messages are sent for.
+The sentry provider uses the `channel` field to specify which environment the messages are sent for:
+
+```yaml
+apiVersion: notification.toolkit.fluxcd.io/v1beta1
+kind: Provider
+metadata:
+  name: sentry
+  namespace: default
+spec:
+  type: sentry
+  channel: my-cluster-name
+  # webhook address (ignored if secretRef is specified)
+  address: https://....@sentry.io/12341234
+```
 
 ### Azure Event Hub
 

--- a/docs/spec/v1beta1/provider.md
+++ b/docs/spec/v1beta1/provider.md
@@ -224,6 +224,10 @@ kubectl create secret generic $SECRET_NAME \
   --from-file=caFile=ca.crt
 ```
 
+### Sentry
+
+The sentry provider uses the `channel` field to specify which environment the messages are sent for.
+
 ### Azure Event Hub
 
 The Azure Event Hub supports two authentication methods, [JWT](https://docs.microsoft.com/en-us/azure/event-hubs/authenticate-application) and [SAS](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-shared-access-signature) based.

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -74,7 +74,7 @@ func (f Factory) Notifier(provider string) (Interface, error) {
 	case v1beta1.WebexProvider:
 		n, err = NewWebex(f.URL, f.ProxyURL, f.CertPool)
 	case v1beta1.SentryProvider:
-		n, err = NewSentry(f.CertPool, f.URL)
+		n, err = NewSentry(f.CertPool, f.URL, f.Channel)
 	case v1beta1.AzureEventHubProvider:
 		n, err = NewAzureEventHub(f.URL, f.Token, f.Channel)
 	default:

--- a/internal/notifier/sentry.go
+++ b/internal/notifier/sentry.go
@@ -32,7 +32,7 @@ type Sentry struct {
 }
 
 // NewSentry creates a Sentry client from the provided Data Source Name (DSN)
-func NewSentry(certPool *x509.CertPool, dsn string) (*Sentry, error) {
+func NewSentry(certPool *x509.CertPool, dsn string, environment string) (*Sentry, error) {
 	tr := &http.Transport{}
 	if certPool != nil {
 		tr = &http.Transport{
@@ -43,6 +43,7 @@ func NewSentry(certPool *x509.CertPool, dsn string) (*Sentry, error) {
 	}
 	client, err := sentry.NewClient(sentry.ClientOptions{
 		Dsn:           dsn,
+		Environment:   environment,
 		HTTPTransport: tr,
 	})
 	if err != nil {

--- a/internal/notifier/sentry_test.go
+++ b/internal/notifier/sentry_test.go
@@ -30,9 +30,10 @@ import (
 )
 
 func TestNewSentry(t *testing.T) {
-	s, err := NewSentry(nil, "https://test@localhost/1")
+	s, err := NewSentry(nil, "https://test@localhost/1", "foo")
 	require.NoError(t, err)
 	assert.Equal(t, s.Client.Options().Dsn, "https://test@localhost/1")
+	assert.Equal(t, s.Client.Options().Environment, "foo")
 }
 
 func TestToSentryEvent(t *testing.T) {


### PR DESCRIPTION
use channel configuration for sentry environment to re-use the same DSN for multiple clusters

created this as a separate PR to not clash with the other sentry PR