### PR TITLE
providers/sentry: send traces

### DIFF
--- a/docs/spec/v1beta1/provider.md
+++ b/docs/spec/v1beta1/provider.md
@@ -241,6 +241,8 @@ spec:
   address: https://....@sentry.io/12341234
 ```
 
+The sentry provider also sends traces for events with the severity Info. This can be disabled by setting the `eventSeverity` field on the related `Alert` Rule to `error`.
+
 ### Azure Event Hub
 
 The Azure Event Hub supports two authentication methods, [JWT](https://docs.microsoft.com/en-us/azure/event-hubs/authenticate-application) and [SAS](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-shared-access-signature) based.

--- a/internal/notifier/sentry_test.go
+++ b/internal/notifier/sentry_test.go
@@ -68,3 +68,40 @@ func TestToSentryEvent(t *testing.T) {
 	}, s.Extra)
 	assert.Equal(t, "message", s.Message)
 }
+
+func TestToSentrySpan(t *testing.T) {
+	// Construct test event
+	e := events.Event{
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "GitRepository",
+			Namespace: "flux-system",
+			Name:      "test-app",
+		},
+		Severity:  "info",
+		Timestamp: metav1.Date(2020, 01, 01, 0, 0, 0, 0, time.UTC),
+		Message:   "message",
+		Metadata: map[string]string{
+			"key1": "val1",
+			"key2": "val2",
+		},
+		ReportingController: "source-controller",
+	}
+
+	// Map to Sentry event
+	s := eventToSpan(e)
+
+	// Assertions
+	assert.Equal(t, time.Date(2020, 01, 01, 0, 0, 0, 0, time.UTC), s.Timestamp)
+	assert.Equal(t, "transaction", s.Type)
+	assert.Equal(t, map[string]string{
+		"flux_involved_object_kind":      e.InvolvedObject.Kind,
+		"flux_involved_object_name":      e.InvolvedObject.Name,
+		"flux_involved_object_namespace": e.InvolvedObject.Namespace,
+		"flux_reason":                    e.Reason,
+		"flux_reporting_controller":      e.ReportingController,
+		"flux_reporting_instance":        e.ReportingInstance,
+		"key1":                           "val1",
+		"key2":                           "val2",
+	}, s.Tags)
+	assert.Equal(t, "message", s.Message)
+}


### PR DESCRIPTION
This is the last sentry PR, I promise 😄 

This PR adds support to send Sentry Traces instead of just errors. This means that normal info events are sent as traces and errors are sent as errors. 

This functionality can be disabled by setting `eventSeverity` in the related `Alert` object to `error`