### PR TITLE
feat: set default observedGeneration to -1 on CRDs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,6 +49,19 @@ jobs:
           KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
       - name: Load test image
         run: kind load docker-image test/notification-controller:latest
+      - name: Install CRDs
+        run: make install
+      - name: Run default status test
+        run: |
+          kubectl apply -f config/testdata/status-defaults
+          for crd in alert provider receiver ; do
+            RESULT=$(kubectl get ${crd} status-defaults -o go-template={{.status}})
+            EXPECTED='map[observedGeneration:-1]'
+            if [ "${RESULT}" != "${EXPECTED}" ] ; then
+              echo -e "${RESULT}\n\ndoes not equal\n\n${EXPECTED} for CRD ${crd}"
+              exit 1
+            fi
+          done
       - name: Deploy controller
         run: |
           make dev-deploy IMG=test/notification-controller:latest

--- a/api/v1beta1/alert_types.go
+++ b/api/v1beta1/alert_types.go
@@ -79,7 +79,8 @@ type Alert struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   AlertSpec   `json:"spec,omitempty"`
+	Spec AlertSpec `json:"spec,omitempty"`
+	// +kubebuilder:default:={"observedGeneration":-1}
 	Status AlertStatus `json:"status,omitempty"`
 }
 

--- a/api/v1beta1/provider_types.go
+++ b/api/v1beta1/provider_types.go
@@ -84,6 +84,9 @@ const (
 
 // ProviderStatus defines the observed state of Provider
 type ProviderStatus struct {
+	// ObservedGeneration is the last reconciled generation.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
@@ -101,7 +104,8 @@ type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ProviderSpec   `json:"spec,omitempty"`
+	Spec ProviderSpec `json:"spec,omitempty"`
+	// +kubebuilder:default:={"observedGeneration":-1}
 	Status ProviderStatus `json:"status,omitempty"`
 }
 

--- a/api/v1beta1/receiver_types.go
+++ b/api/v1beta1/receiver_types.go
@@ -109,7 +109,8 @@ type Receiver struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ReceiverSpec   `json:"spec,omitempty"`
+	Spec ReceiverSpec `json:"spec,omitempty"`
+	// +kubebuilder:default:={"observedGeneration":-1}
 	Status ReceiverStatus `json:"status,omitempty"`
 }
 

--- a/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
@@ -109,6 +109,8 @@ spec:
             - providerRef
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: AlertStatus defines the observed state of Alert
             properties:
               conditions:

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -98,6 +98,8 @@ spec:
             - type
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: ProviderStatus defines the observed state of Provider
             properties:
               conditions:
@@ -143,6 +145,10 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: ObservedGeneration is the last reconciled generation.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
@@ -114,6 +114,8 @@ spec:
             - type
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: ReceiverStatus defines the observed state of Receiver
             properties:
               conditions:

--- a/config/testdata/provider.yaml
+++ b/config/testdata/provider.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta1
+kind: Provider
+metadata:
+  name: status-defaults
+spec:
+  type: generic
+

--- a/config/testdata/status-defaults/alert.yaml
+++ b/config/testdata/status-defaults/alert.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta1
+kind: Alert
+metadata:
+  name: status-defaults

--- a/config/testdata/status-defaults/provider.yaml
+++ b/config/testdata/status-defaults/provider.yaml
@@ -1,0 +1,4 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta1
+kind: Provider
+metadata:
+  name: status-defaults

--- a/config/testdata/status-defaults/receiver.yaml
+++ b/config/testdata/status-defaults/receiver.yaml
@@ -1,0 +1,4 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta1
+kind: Receiver
+metadata:
+  name: status-defaults

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -814,6 +814,18 @@ a PEM-encoded CA certificate (<code>caFile</code>)</p>
 <tbody>
 <tr>
 <td>
+<code>observedGeneration</code><br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the last reconciled generation.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>conditions</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#condition-v1-meta">


### PR DESCRIPTION
This sets the `status.observedGeneration` field to -1 by default. This
is a follow-up to https://github.com/fluxcd/helm-controller/pull/294,
porting the same code to the notification-controller so that all Flux
2 controllers work the same way in this regard.

Signed-off-by: Max Jonas Werner <mail@makk.es>