### PR TITLE
Add alertmanager provider

### DIFF
--- a/api/v1beta1/provider_types.go
+++ b/api/v1beta1/provider_types.go
@@ -28,7 +28,7 @@ const (
 // ProviderSpec defines the desired state of Provider
 type ProviderSpec struct {
 	// Type of provider
-	// +kubebuilder:validation:Enum=slack;discord;msteams;rocket;generic;github;gitlab;bitbucket;azuredevops;googlechat;webex;sentry;azureeventhub;telegram;lark;matrix;opsgenie;
+	// +kubebuilder:validation:Enum=slack;discord;msteams;rocket;generic;github;gitlab;bitbucket;azuredevops;googlechat;webex;sentry;azureeventhub;telegram;lark;matrix;opsgenie;alertmanager;
 	// +required
 	Type string `json:"type"`
 
@@ -81,6 +81,7 @@ const (
 	LarkProvider          string = "lark"
 	Matrix                string = "matrix"
 	OpsgenieProvider      string = "opsgenie"
+	AlertManagerProvider  string = "alertmanager"
 )
 
 // ProviderStatus defines the observed state of Provider

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -91,6 +91,7 @@ spec:
                 - lark
                 - matrix
                 - opsgenie
+                - alertmanager
                 type: string
               username:
                 description: Bot username for this provider

--- a/internal/notifier/alertmanager.go
+++ b/internal/notifier/alertmanager.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notifier
+
+import (
+	"crypto/x509"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/fluxcd/pkg/runtime/events"
+)
+
+type Alertmanager struct {
+	URL      string
+	ProxyURL string
+	CertPool *x509.CertPool
+}
+
+type AlertManagerAlert struct {
+	Status      string            `json:"status"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+func NewAlertmanager(hookURL string, proxyURL string, certPool *x509.CertPool) (*Alertmanager, error) {
+	_, err := url.ParseRequestURI(hookURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Alertmanager URL %s", hookURL)
+	}
+
+	return &Alertmanager{
+		URL:      hookURL,
+		ProxyURL: proxyURL,
+		CertPool: certPool,
+	}, nil
+}
+
+func (s *Alertmanager) Post(event events.Event) error {
+	// Skip any update events
+	if isCommitStatus(event.Metadata, "update") {
+		return nil
+	}
+
+	annotations := make(map[string]string)
+	annotations["message"] = event.Message
+
+	_, ok := event.Metadata["summary"]
+	if ok {
+		annotations["summary"] = event.Metadata["summary"]
+		delete(event.Metadata, "summary")
+	}
+
+	labels := event.Metadata
+	labels["alertname"] = "Flux" + event.InvolvedObject.Kind + strings.Title(event.Reason)
+	labels["severity"] = event.Severity
+	labels["reason"] = event.Reason
+
+	labels["kind"] = event.InvolvedObject.Kind
+	labels["name"] = event.InvolvedObject.Name
+	labels["namespace"] = event.InvolvedObject.Namespace
+	labels["reportingcontroller"] = event.ReportingController
+
+	payload := []AlertManagerAlert{
+		{
+			Labels:      labels,
+			Annotations: annotations,
+			Status:      "firing",
+		},
+	}
+
+	err := postMessage(s.URL, s.ProxyURL, s.CertPool, payload)
+
+	if err != nil {
+		return fmt.Errorf("postMessage failed: %w", err)
+	}
+	return nil
+}

--- a/internal/notifier/alertmanger_test.go
+++ b/internal/notifier/alertmanger_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notifier
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertmanager_Post(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err)
+		var payload []AlertManagerAlert
+		err = json.Unmarshal(b, &payload)
+		require.NoError(t, err)
+
+	}))
+	defer ts.Close()
+
+	alertmanager, err := NewAlertmanager(ts.URL, "", nil)
+	require.NoError(t, err)
+
+	err = alertmanager.Post(testEvent())
+	require.NoError(t, err)
+}

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -85,6 +85,8 @@ func (f Factory) Notifier(provider string) (Interface, error) {
 		n, err = NewMatrix(f.URL, f.Token, f.Channel)
 	case v1beta1.OpsgenieProvider:
 		n, err = NewOpsgenie(f.URL, f.ProxyURL, f.CertPool, f.Token)
+	case v1beta1.AlertManagerProvider:
+		n, err = NewAlertmanager(f.URL, f.ProxyURL, f.CertPool)
 	default:
 		err = fmt.Errorf("provider %s not supported", provider)
 	}

--- a/internal/notifier/opsgenie.go
+++ b/internal/notifier/opsgenie.go
@@ -39,7 +39,6 @@ type OpsgenieAlert struct {
 	Details     map[string]string `json:"details"`
 }
 
-// NewSlack validates the Slack URL and returns a Slack object
 func NewOpsgenie(hookURL string, proxyURL string, certPool *x509.CertPool, token string) (*Opsgenie, error) {
 	_, err := url.ParseRequestURI(hookURL)
 	if err != nil {


### PR DESCRIPTION
This commit adds the alertmanager provider. The provider adds some
generic labels based on the event which should be enough to configure
appropraite routes within alertmanager.

The alert is annotated with the message by default and optionally by the
summary field given in the event.