### PR TITLE
Fixed missing setter for Forwarder CertPool

### DIFF
--- a/internal/notifier/forwarder.go
+++ b/internal/notifier/forwarder.go
@@ -46,6 +46,7 @@ func NewForwarder(hookURL string, proxyURL string, certPool *x509.CertPool) (*Fo
 	return &Forwarder{
 		URL:      hookURL,
 		ProxyURL: proxyURL,
+		CertPool: certPool,
 	}, nil
 }
 


### PR DESCRIPTION
This fixes a bug whereby the configured root CA was not being used for the generic webhook method.