### PR TITLE
Feature: Add option to pass additional headers via secretRef to the generic notification provider

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -97,7 +97,8 @@ jobs:
       - name: Run smoke tests
         run: |
           kubectl -n notification-system apply -f ./config/samples
-          kubectl -n notification-system wait provider/provider-sample --for=condition=ready --timeout=1m
+          kubectl -n notification-system wait provider/slack-provider-sample --for=condition=ready --timeout=1m
+          kubectl -n notification-system wait provider/generic-provider-sample --for=condition=ready --timeout=1m
           kubectl -n notification-system wait alert/alert-sample --for=condition=ready --timeout=1m
           kubectl -n notification-system wait receiver/receiver-sample --for=condition=ready --timeout=1m
       - name: Logs

--- a/config/samples/notification_v1beta1_provider.yaml
+++ b/config/samples/notification_v1beta1_provider.yaml
@@ -1,7 +1,7 @@
 apiVersion: notification.toolkit.fluxcd.io/v1beta1
 kind: Provider
 metadata:
-  name: provider-sample
+  name: slack-provider-sample
 spec:
   type: slack
   channel: general
@@ -14,3 +14,20 @@ metadata:
   name: slack-url
 data:
   address: aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMv
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta1
+kind: Provider
+metadata:
+  name: generic-provider-sample
+spec:
+  type: generic
+  address: https://api.github.com/repos/fluxcd/notification-controller/dispatches
+  secretRef:
+    name: generic-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: generic-secret
+data:
+  headers: QXV0aG9yaXphdGlvbjogdG9rZW4KWC1Gb3J3YXJkZWQtUHJvdG86IGh0dHBz

--- a/controllers/provider_controller.go
+++ b/controllers/provider_controller.go
@@ -31,8 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"

--- a/docs/spec/v1beta1/provider.md
+++ b/docs/spec/v1beta1/provider.md
@@ -163,6 +163,28 @@ The body of the request looks like this:
 
 The `involvedObject` key contains the object that triggered the event.
 
+```yaml
+apiVersion: notification.toolkit.fluxcd.io/v1beta1
+kind: Provider
+metadata:
+  name: generic
+  namespace: default
+spec:
+  type: generic
+  address: https://api.github.com/repos/owner/repo/dispatches
+  secretRef: 
+    name: generic-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: generic-secret
+  namespace: default
+data:
+  # 'Authorization: token\nX-Forwarded-Proto: https'
+  headers: QXV0aG9yaXphdGlvbjogdG9rZW4KWC1Gb3J3YXJkZWQtUHJvdG86IGh0dHBz
+```
+
 ### Self-signed certificates
 
 The `certSecretRef` field names a secret with TLS certificate data. This is for the purpose

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/whilp/git-urls v1.0.0
 	github.com/xanzy/go-gitlab v0.50.4
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2

--- a/go.mod
+++ b/go.mod
@@ -29,9 +29,9 @@ require (
 	github.com/whilp/git-urls v1.0.0
 	github.com/xanzy/go-gitlab v0.50.4
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
 	sigs.k8s.io/controller-runtime v0.10.2
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -29,16 +29,18 @@ type Factory struct {
 	Username string
 	Channel  string
 	Token    string
+	Headers  map[string]string
 	CertPool *x509.CertPool
 }
 
-func NewFactory(url string, proxy string, username string, channel string, token string, certPool *x509.CertPool) *Factory {
+func NewFactory(url string, proxy string, username string, channel string, token string, headers map[string]string, certPool *x509.CertPool) *Factory {
 	return &Factory{
 		URL:      url,
 		ProxyURL: proxy,
 		Channel:  channel,
 		Username: username,
 		Token:    token,
+		Headers:  headers,
 		CertPool: certPool,
 	}
 }
@@ -52,7 +54,7 @@ func (f Factory) Notifier(provider string) (Interface, error) {
 	var err error
 	switch provider {
 	case v1beta1.GenericProvider:
-		n, err = NewForwarder(f.URL, f.ProxyURL, f.CertPool)
+		n, err = NewForwarder(f.URL, f.ProxyURL, f.Headers, f.CertPool)
 	case v1beta1.SlackProvider:
 		n, err = NewSlack(f.URL, f.ProxyURL, f.Token, f.CertPool, f.Username, f.Channel)
 	case v1beta1.DiscordProvider:

--- a/internal/notifier/forwarder_test.go
+++ b/internal/notifier/forwarder_test.go
@@ -34,6 +34,7 @@ func TestForwarder_Post(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "source-controller", r.Header.Get("gotk-component"))
+		require.Equal(t, "token", r.Header.Get("Authorization"))
 		var payload = events.Event{}
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
@@ -42,7 +43,9 @@ func TestForwarder_Post(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	forwarder, err := NewForwarder(ts.URL, "", nil)
+	headers := make(map[string]string)
+	headers["Authorization"] = "token"
+	forwarder, err := NewForwarder(ts.URL, "", headers, nil)
 	require.NoError(t, err)
 
 	err = forwarder.Post(testEvent())

--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"io"
 	"net/http"
 	"regexp"
@@ -139,6 +140,7 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 
 			webhook := provider.Spec.Address
 			token := ""
+			headers := make(map[string]string)
 			if provider.Spec.SecretRef != nil {
 				var secret corev1.Secret
 				secretName := types.NamespacedName{Namespace: alert.Namespace, Name: provider.Spec.SecretRef.Name}
@@ -158,6 +160,17 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 
 				if t, ok := secret.Data["token"]; ok {
 					token = string(t)
+				}
+
+				if h, ok := secret.Data["headers"]; ok {
+					err := yaml.Unmarshal(h, headers)
+					if err != nil {
+						s.logger.Error(err, "failed to read headers from secret",
+							"reconciler kind", v1beta1.ProviderKind,
+							"name", providerName.Name,
+							"namespace", providerName.Namespace)
+						continue
+					}
 				}
 			}
 
@@ -203,7 +216,7 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 				continue
 			}
 
-			factory := notifier.NewFactory(webhook, provider.Spec.Proxy, provider.Spec.Username, provider.Spec.Channel, token, certPool)
+			factory := notifier.NewFactory(webhook, provider.Spec.Proxy, provider.Spec.Username, provider.Spec.Channel, token, headers, certPool)
 			sender, err := factory.Notifier(provider.Spec.Type)
 			if err != nil {
 				s.logger.Error(err, "failed to initialize provider",

--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io"
 	"net/http"
 	"regexp"
@@ -31,6 +30,7 @@ import (
 	"github.com/fluxcd/pkg/runtime/conditions"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
 
 	"github.com/fluxcd/pkg/runtime/events"
 


### PR DESCRIPTION
The generic notification provider should have a little more configuration options.

We have a use-case where we want to kick-off Github workflows based on deployments. A feature to add additional headers would allow us to do this. Without additional headers we are not able to authenticate with Github though, since it requires an `Authorization` header with the personal access token set.