### PR TITLE
Add timestamp as label for alertmanager

### DIFF
--- a/docs/spec/v1beta1/provider.md
+++ b/docs/spec/v1beta1/provider.md
@@ -333,6 +333,7 @@ The provider will send the following labels for the event.
 | ----------- | -------------------------------------------------------------------------------------------------- |
 | alertname   | The string Flux followed by the Kind and the reason for the event e.g FluxKustomizationProgressing |
 | severity    | The severity of the event (error|info)                                                             |
+| timestamp   | The timestamp of the event                                                                         |
 | reason      | The machine readable reason for the objects transition into the current status                     |
 | kind        | The kind of the involved object associated with the event                                          |
 | name        | The name of the involved object associated with the event                                          |

--- a/internal/notifier/alertmanager.go
+++ b/internal/notifier/alertmanager.go
@@ -72,6 +72,7 @@ func (s *Alertmanager) Post(event events.Event) error {
 	labels["alertname"] = "Flux" + event.InvolvedObject.Kind + strings.Title(event.Reason)
 	labels["severity"] = event.Severity
 	labels["reason"] = event.Reason
+	labels["timestamp"] = event.Timestamp.String()
 
 	labels["kind"] = event.InvolvedObject.Kind
 	labels["name"] = event.InvolvedObject.Name


### PR DESCRIPTION
Without the timestamp there is not enough entropy in the hash for
alertmanager to recongise that this is a new alert for some cases.

Adding the timestamp ensures that a new hash for the alert is created
each time and therefore no updates get missed.