### PR TITLE
Add documentation for gitea

### DIFF
--- a/docs/spec/v1beta1/receiver.md
+++ b/docs/spec/v1beta1/receiver.md
@@ -199,6 +199,12 @@ spec:
 Note that you have to set the generated token as the GitHub webhook secret value.
 The controller uses the `X-Hub-Signature` HTTP header to verify that the request is legitimate.
 
+
+### Gitea receiver
+
+The Gitea webhook works with the [Github receiver](#github-receiver). You can use the same example
+given for the Github receiver.
+
 ### GitLab receiver
 
 ```yaml


### PR DESCRIPTION
Closes: #230 

The Gitea webhooks work with the github receiver implementation. So this pull request just adds documentation.

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>