### PR TITLE
Replace cifuzz with custom smoke test

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -7,21 +7,14 @@ jobs:
   Fuzzing:
     runs-on: ubuntu-latest
     steps:
-    - name: Build Fuzzers
-      id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Restore Go cache
+      uses: actions/cache@v1
       with:
-        oss-fuzz-project-name: 'fluxcd'
-        language: go
-    - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-      with:
-        oss-fuzz-project-name: 'fluxcd'
-        language: go
-        fuzz-seconds: 60
-    - name: Upload Crash
-      uses: actions/upload-artifact@v1
-      if: failure() && steps.build.outcome == 'success'
-      with:
-        name: artifacts
-        path: ./out/artifacts
+        path: /home/runner/work/_temp/_github_home/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Smoke test Fuzzers
+      run: make fuzz-smoketest

--- a/Makefile
+++ b/Makefile
@@ -115,19 +115,18 @@ fuzz-build:
 	mkdir -p $(shell pwd)/build/fuzz/out/
 
 	docker build . --tag local-fuzzing:latest -f tests/fuzz/Dockerfile.builder
-	docker run --rm -it \
-		-e FUZZING_LANGUAGE=go -e FUZZ_SECONDS=600 -e MODE=batch \
+	docker run --rm \
+		-e FUZZING_LANGUAGE=go -e SANITIZER=address \
 		-e CIFUZZ_DEBUG='True' -e OSS_FUZZ_PROJECT_NAME=fluxcd \
-		-e SANITIZER=address \
 		-v "$(shell pwd)/build/fuzz/out":/out \
 		local-fuzzing:latest
 
 # Run each fuzzer once to ensure they are working
 fuzz-smoketest: fuzz-build
-	docker run --rm -ti \
+	docker run --rm \
 		-v "$(shell pwd)/build/fuzz/out":/out \
 		-v "$(shell pwd)/tests/fuzz/oss_fuzz_run.sh":/runner.sh \
-		gcr.io/oss-fuzz/fluxcd \
+		local-fuzzing:latest \
 		bash -c "/runner.sh"
 
 # Find or download controller-gen


### PR DESCRIPTION
Use the project specific smoke test to ensure the fuzzer correctness instead of using the official oss-fuzz GitHub action, which does not support well the multi-repository approach that FluxCD requires.