### PR TITLE
drop capabilities, enable seccomp and enforce runAsNonRoot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,6 @@ COPY --from=builder /workspace/notification-controller /usr/local/bin/
 # https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-RUN addgroup -S controller && adduser -S controller -G controller
-
-USER controller
+USER 65534:65534
 
 ENTRYPOINT [ "/sbin/tini", "--", "notification-controller" ]

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: [ "ALL" ]
+          seccompProfile:
+            type: RuntimeDefault
         ports:
           - containerPort: 9090
             name: http


### PR DESCRIPTION
Further restricts the SecurityContext that the controller runs under, by enabling the default seccomp profile and dropping all linux capabilities.
This was set at container-level to ensure backwards compatibility with use cases in which sidecars are injected into the source-controller pod
without setting less restrictive settings.
Add a uid and gid for the container to enforce runAsNonRoot and ensure
the use of non root users.

BREAKING CHANGES:
1) The use of new seccomp API requires Kubernetes 1.19.
2) the controller container is now executed under 65534:65534 (userid:groupid).
   This change may break deployments that hard-coded the user name 'controller' in their PodSecurityPolicy.

Ref: fluxcd/flux2#2014

Signed-off-by: Sanskar Jaiswal <sanskar.jaiswal@weave.works>
Co-authored-by: Paulo Gomes <paulo.gomes@weave.works>