### PR TITLE
Commit status notifications: Add optional prefix to commit status key

### DIFF
--- a/api/v1beta1/provider_types.go
+++ b/api/v1beta1/provider_types.go
@@ -32,6 +32,14 @@ type ProviderSpec struct {
 	// +required
 	Type string `json:"type"`
 
+	// A string to prepend to the identifier of a commit status.
+	// Example use-case: a single object (kustomization/k8s-gitops)
+	// is deployed to multiple clusters. Specifying this (e.g., to
+	// the name of the cluster) ensures that the notification controllers
+	// on each cluster don't overwrite each others' commit statuses.
+	// +optional
+	CommitStatusPrefix string `json:"commitStatusPrefix,omitempty"`
+
 	// Alert channel for this provider
 	// +optional
 	Channel string `json:"channel,omitempty"`

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -63,6 +63,13 @@ spec:
               channel:
                 description: Alert channel for this provider
                 type: string
+              commitStatusPrefix:
+                description: 'A string to prepend to the identifier of a commit status.
+                  Example use-case: a single object (kustomization/k8s-gitops) is
+                  deployed to multiple clusters. Specifying this (e.g., to the name
+                  of the cluster) ensures that the notification controllers on each
+                  cluster don''t overwrite each others'' commit statuses.'
+                type: string
               proxy:
                 description: HTTP/S address of the proxy
                 pattern: ^(http|https)://

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -237,6 +237,22 @@ string
 </tr>
 <tr>
 <td>
+<code>commitStatusPrefix</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>A string to prepend to the identifier of a commit status.
+Example use-case: a single object (kustomization/k8s-gitops)
+is deployed to multiple clusters. Specifying this (e.g., to
+the name of the cluster) ensures that the notification controllers
+on each cluster don&rsquo;t overwrite each others&rsquo; commit statuses.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>channel</code><br>
 <em>
 string
@@ -738,6 +754,22 @@ string
 </td>
 <td>
 <p>Type of provider</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>commitStatusPrefix</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>A string to prepend to the identifier of a commit status.
+Example use-case: a single object (kustomization/k8s-gitops)
+is deployed to multiple clusters. Specifying this (e.g., to
+the name of the cluster) ensures that the notification controllers
+on each cluster don&rsquo;t overwrite each others&rsquo; commit statuses.</p>
 </td>
 </tr>
 <tr>

--- a/internal/notifier/util.go
+++ b/internal/notifier/util.go
@@ -46,7 +46,16 @@ func parseGitAddress(s string) (string, string, error) {
 }
 
 func formatNameAndDescription(event events.Event) (string, string) {
-	name := fmt.Sprintf("%v/%v", event.InvolvedObject.Kind, event.InvolvedObject.Name)
+	kind, name := event.InvolvedObject.Kind, event.InvolvedObject.Name
+	commitStatusPrefix, ok := event.Metadata["commitStatusPrefix"]
+	if ok && commitStatusPrefix != "" {
+		// This adds additional information to the identifier of a commit status so that,
+		// for example, notification controllers deployed on multiple clusters hosting
+		// the same resource kind/name don't overwrite each others' commit statuses.
+		name = fmt.Sprintf("%v/%v/%v", commitStatusPrefix, kind, name)
+	} else {
+		name = fmt.Sprintf("%v/%v", kind, name)
+	}
 	name = strings.ToLower(name)
 	desc := strings.Join(splitCamelcase(event.Reason), " ")
 	desc = strings.ToLower(desc)

--- a/internal/notifier/util_test.go
+++ b/internal/notifier/util_test.go
@@ -25,15 +25,32 @@ import (
 )
 
 func TestUtil_NameAndDescription(t *testing.T) {
-	event := events.Event{
+	var event events.Event
+	var name, desc string
+
+	event = events.Event{
 		InvolvedObject: v1.ObjectReference{
 			Kind: "Kustomization",
 			Name: "gitops-system",
 		},
 		Reason: "ApplySucceeded",
 	}
-	name, desc := formatNameAndDescription(event)
+	name, desc = formatNameAndDescription(event)
 	require.Equal(t, "kustomization/gitops-system", name)
+	require.Equal(t, "apply succeeded", desc)
+
+	event = events.Event{
+		InvolvedObject: v1.ObjectReference{
+			Kind: "Kustomization",
+			Name: "gitops-system",
+		},
+		Reason: "ApplySucceeded",
+		Metadata: map[string]string{
+			"commitStatusPrefix": "im-a-cluster",
+		},
+	}
+	name, desc = formatNameAndDescription(event)
+	require.Equal(t, "im-a-cluster/kustomization/gitops-system", name)
 	require.Equal(t, "apply succeeded", desc)
 }
 

--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -259,6 +259,16 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 				}
 			}
 
+			if provider.Spec.CommitStatusPrefix != "" {
+				if notification.Metadata == nil {
+					notification.Metadata = map[string]string{
+						"commitStatusPrefix": provider.Spec.CommitStatusPrefix,
+					}
+				} else {
+					notification.Metadata["commitStatusPrefix"] = provider.Spec.CommitStatusPrefix
+				}
+			}
+
 			go func(n notifier.Interface, e events.Event) {
 				if err := n.Post(e); err != nil {
 					err = redactTokenFromError(err, token)


### PR DESCRIPTION
This PR aims to extend the functionality of commit status notifications. It adds an optional key `commitStatusPrefix` to the Provider spec so that notification controllers in different environments don't overwrite a commit status for a particular resource.

Example use-case: a single object (kustomization/k8s-gitops) is deployed to multiple clusters. Specifying this (e.g. to the name of the cluster) ensures that the notification controllers on each cluster don't overwrite each others' commit statuses when reporting on kustomization/k8s-gitops.