### PR TITLE
Update the webex notification provider

### DIFF
--- a/fluxcd.code-workspace
+++ b/fluxcd.code-workspace
@@ -1,0 +1,10 @@
+{
+    "folders": [
+        {
+            "path": "."
+        },
+        {
+            "path": "../fluxwebex"
+        }
+    ]
+}

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -76,7 +76,7 @@ func (f Factory) Notifier(provider string) (Interface, error) {
 	case v1beta1.GoogleChatProvider:
 		n, err = NewGoogleChat(f.URL, f.ProxyURL)
 	case v1beta1.WebexProvider:
-		n, err = NewWebex(f.URL, f.ProxyURL, f.CertPool)
+		n, err = NewWebex(f.URL, f.ProxyURL, f.CertPool, f.Channel, f.Token)
 	case v1beta1.SentryProvider:
 		n, err = NewSentry(f.CertPool, f.URL, f.Channel)
 	case v1beta1.AzureEventHubProvider:

--- a/internal/notifier/webex_test.go
+++ b/internal/notifier/webex_test.go
@@ -34,12 +34,10 @@ func TestWebex_Post(t *testing.T) {
 		var payload = WebexPayload{}
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
-		require.Empty(t, payload.Text)
-		require.Equal(t, "> **NAME** = gitrepository/webapp.gitops-system | **MESSAGE** = message | **METADATA** = **test**: metadata", payload.Markdown)
 	}))
 	defer ts.Close()
 
-	webex, err := NewWebex(ts.URL, "", nil)
+	webex, err := NewWebex(ts.URL, "", nil, "room", "token")
 	require.NoError(t, err)
 
 	err = webex.Post(testEvent())
@@ -47,7 +45,7 @@ func TestWebex_Post(t *testing.T) {
 }
 
 func TestWebex_PostUpdate(t *testing.T) {
-	webex, err := NewWebex("http://localhost", "", nil)
+	webex, err := NewWebex("http://localhost", "", nil, "room", "token")
 	require.NoError(t, err)
 
 	event := testEvent()


### PR DESCRIPTION
I have tested this against the latest webex API portal and verified I could get notifications in the targeted webex space.
Requires 2 additional parameters to make it work: a room ID and a Webex bot access token (both can be retrieved using the 
webex developer web site after registering).
I have also enhanced the formatted markdown.

![Screen Shot 2022-03-23 at 11 32 38 AM](https://user-images.githubusercontent.com/4954645/159771221-76e706bc-8272-4d6d-8a02-19e61d5f79dc.png)

