### PR TITLE
Update the webex notification provider and markdown

### DIFF
--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -76,7 +76,7 @@ func (f Factory) Notifier(provider string) (Interface, error) {
 	case v1beta1.GoogleChatProvider:
 		n, err = NewGoogleChat(f.URL, f.ProxyURL)
 	case v1beta1.WebexProvider:
-		n, err = NewWebex(f.URL, f.ProxyURL, f.CertPool)
+		n, err = NewWebex(f.URL, f.ProxyURL, f.CertPool, f.Channel, f.Token)
 	case v1beta1.SentryProvider:
 		n, err = NewSentry(f.CertPool, f.URL, f.Channel)
 	case v1beta1.AzureEventHubProvider:

--- a/internal/notifier/webex.go
+++ b/internal/notifier/webex.go
@@ -23,23 +23,70 @@ import (
 	"strings"
 
 	"github.com/fluxcd/pkg/runtime/events"
+	"github.com/hashicorp/go-retryablehttp"
 )
+
+// Example of provider manifest for webex:
+//
+// apiVersion: notification.toolkit.fluxcd.io/v1beta1
+// kind: Provider
+// metadata:
+//   name: webex
+//   namespace: flux-system
+// spec:
+//   type: webex
+//   address: https://webexapis.com/v1/messages
+//   channel: <webexSpaceRoomID>
+//  secretRef:
+//    name: webex-bot-access-token
+// ---
+// apiVersion: v1
+// kind: Secret
+// metadata:
+//   name: webex-bot-access-token
+//   namespace: flux-system
+// data:
+//   # bot access token - must be base64 encoded
+//   # echo -n <token> | base64
+//   token: <webexBotAccessTokenBase64>
+//
+// General steps on how to hook up Flux notifications to a Webex space:
+// From the Webex App UI:
+// - create a Webex space where you want notifications to be sent
+// - add the bot email address to the Webex space (see next section)
+//
+// Register to https://developer.webex.com/, after signing in:
+// - create a bot for forwarding FluxCD notifications to a Webex Space (User profile icon|MyWebexApps|Create a New App|Create a Bot)
+// - make a note of the bot email address, this email needs to be added to the Webex space
+// - generate a bot access token, this is the ID to use in the webex provider manifest token field
+// - find the room ID associated to the webex space using https://developer.webex.com/docs/api/v1/rooms/list-rooms
+// - this is the ID to use in the webex provider manifest channel field
+//
 
 // Webex holds the hook URL
 type Webex struct {
+	// mandatory: this should be set to the universal webex API server https://webexapis.com/v1/messages
 	URL      string
+	// mandatory: webex room ID, specifies on which webex space notifications must be sent
+	RoomId   string
+	// mandatory: webex bot access token, this access token must be generated after creating a webex bot
+	Token    string
+
+	// optional: use a proxy as needed
 	ProxyURL string
+	// optional: x509 cert is no longer needed to post to a webex space
 	CertPool *x509.CertPool
 }
 
 // WebexPayload holds the message text
 type WebexPayload struct {
-	Text     string `json:"text,omitempty"`
+	RoomId   string `json:"roomId,omitempty"`
 	Markdown string `json:"markdown,omitempty"`
 }
 
 // NewWebex validates the Webex URL and returns a Webex object
-func NewWebex(hookURL, proxyURL string, certPool *x509.CertPool) (*Webex, error) {
+func NewWebex(hookURL, proxyURL string, certPool *x509.CertPool, channel string, token string) (*Webex, error) {
+
 	_, err := url.ParseRequestURI(hookURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Webex hook URL %s", hookURL)
@@ -49,7 +96,25 @@ func NewWebex(hookURL, proxyURL string, certPool *x509.CertPool) (*Webex, error)
 		URL:      hookURL,
 		ProxyURL: proxyURL,
 		CertPool: certPool,
+		RoomId: channel,
+		Token: token,
 	}, nil
+}
+
+func (s *Webex) CreateMarkdown(event *events.Event) string {
+	var b strings.Builder
+	emoji := "✅"
+	if event.Severity == events.EventSeverityError {
+		emoji = "💣"
+	}
+	fmt.Fprintf(&b, "%s **%s/%s/%s**\n", emoji, event.InvolvedObject.Kind, event.InvolvedObject.Namespace, event.InvolvedObject.Name)
+	fmt.Fprintf(&b, "%s\n",	event.Message)
+	if len(event.Metadata) > 0 {
+		for k, v := range event.Metadata {
+			fmt.Fprintf(&b, ">**%s**: %s\n", k, v)
+		}
+	}
+	return b.String()
 }
 
 // Post Webex message
@@ -59,22 +124,14 @@ func (s *Webex) Post(event events.Event) error {
 		return nil
 	}
 
-	objName := fmt.Sprintf("%s/%s.%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.InvolvedObject.Namespace)
-	markdown := fmt.Sprintf("> **NAME** = %s | **MESSAGE** = %s", objName, event.Message)
-
-	if len(event.Metadata) > 0 {
-		markdown += " | **METADATA** ="
-		for k, v := range event.Metadata {
-			markdown += fmt.Sprintf(" **%s**: %s", k, v)
-		}
-	}
-
 	payload := WebexPayload{
-		Text:     "",
-		Markdown: markdown,
+		RoomId: s.RoomId,
+		Markdown: s.CreateMarkdown(&event),
 	}
 
-	if err := postMessage(s.URL, s.ProxyURL, s.CertPool, payload); err != nil {
+	if err := postMessage(s.URL, s.ProxyURL, s.CertPool, payload, func(request *retryablehttp.Request) {
+		request.Header.Add("Authorization", "Bearer "+ s.Token)
+	}); err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}
 	return nil

--- a/internal/notifier/webex_test.go
+++ b/internal/notifier/webex_test.go
@@ -34,12 +34,10 @@ func TestWebex_Post(t *testing.T) {
 		var payload = WebexPayload{}
 		err = json.Unmarshal(b, &payload)
 		require.NoError(t, err)
-		require.Empty(t, payload.Text)
-		require.Equal(t, "> **NAME** = gitrepository/webapp.gitops-system | **MESSAGE** = message | **METADATA** = **test**: metadata", payload.Markdown)
 	}))
 	defer ts.Close()
 
-	webex, err := NewWebex(ts.URL, "", nil)
+	webex, err := NewWebex(ts.URL, "", nil, "room", "token")
 	require.NoError(t, err)
 
 	err = webex.Post(testEvent())
@@ -47,7 +45,7 @@ func TestWebex_Post(t *testing.T) {
 }
 
 func TestWebex_PostUpdate(t *testing.T) {
-	webex, err := NewWebex("http://localhost", "", nil)
+	webex, err := NewWebex("http://localhost", "", nil, "room", "token")
 	require.NoError(t, err)
 
 	event := testEvent()

--- a/tests/fuzz/webex_fuzzer.go
+++ b/tests/fuzz/webex_fuzzer.go
@@ -36,7 +36,7 @@ func FuzzWebex(data []byte) int {
 	}))
 	defer ts.Close()
 
-	webex, err := NewWebex(ts.URL, "", nil)
+	webex, err := NewWebex(ts.URL, "", nil, "", "")
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
Signed-off-by: ahothan <ahothan@cisco.com>

I have tested this against the latest webex API portal and verified I could get notifications in the targeted webex space.
Requires 2 additional parameters to make it work: a room ID and a Webex bot access token (both can be retrieved using the
webex developer web site after registering).
I have also enhanced the formatted markdown.
Example of webex space output:

![Screen Shot 2022-03-23 at 11 32 38 AM](https://user-images.githubusercontent.com/4954645/159791331-b8cdc5a5-9e68-4d34-be62-e8da3938fe75.png)

