### PR TITLE
Better error messages for alert providers

### DIFF
--- a/internal/notifier/alertmanager.go
+++ b/internal/notifier/alertmanager.go
@@ -40,7 +40,7 @@ type AlertManagerAlert struct {
 func NewAlertmanager(hookURL string, proxyURL string, certPool *x509.CertPool) (*Alertmanager, error) {
 	_, err := url.ParseRequestURI(hookURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid Alertmanager URL %s", hookURL)
+		return nil, fmt.Errorf("invalid Alertmanager URL %s: '%w'", hookURL, err)
 	}
 
 	return &Alertmanager{

--- a/internal/notifier/discord.go
+++ b/internal/notifier/discord.go
@@ -37,7 +37,7 @@ type Discord struct {
 func NewDiscord(hookURL string, proxyURL string, username string, channel string) (*Discord, error) {
 	webhook, err := url.ParseRequestURI(hookURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid Discord hook URL %s", hookURL)
+		return nil, fmt.Errorf("invalid Discord hook URL %s: '%w'", hookURL, err)
 	}
 
 	// use Slack formatting

--- a/internal/notifier/matrix.go
+++ b/internal/notifier/matrix.go
@@ -28,7 +28,7 @@ type MatrixPayload struct {
 func NewMatrix(serverURL, token, roomId string, certPool *x509.CertPool) (*Matrix, error) {
 	_, err := url.ParseRequestURI(serverURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid Matrix homeserver URL %s", serverURL)
+		return nil, fmt.Errorf("invalid Matrix homeserver URL %s: '%w'", serverURL, err)
 	}
 
 	return &Matrix{

--- a/internal/notifier/opsgenie.go
+++ b/internal/notifier/opsgenie.go
@@ -42,7 +42,7 @@ type OpsgenieAlert struct {
 func NewOpsgenie(hookURL string, proxyURL string, certPool *x509.CertPool, token string) (*Opsgenie, error) {
 	_, err := url.ParseRequestURI(hookURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid Opsgenie hook URL %s", hookURL)
+		return nil, fmt.Errorf("invalid Opsgenie hook URL %s: '%w'", hookURL, err)
 	}
 
 	if token == "" {

--- a/internal/notifier/rocket.go
+++ b/internal/notifier/rocket.go
@@ -39,7 +39,7 @@ type Rocket struct {
 func NewRocket(hookURL string, proxyURL string, certPool *x509.CertPool, username string, channel string) (*Rocket, error) {
 	_, err := url.ParseRequestURI(hookURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid Rocket hook URL %s", hookURL)
+		return nil, fmt.Errorf("invalid Rocket hook URL %s: '%w'", hookURL, err)
 	}
 
 	if username == "" {

--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -65,7 +65,7 @@ type SlackField struct {
 func NewSlack(hookURL string, proxyURL string, token string, certPool *x509.CertPool, username string, channel string) (*Slack, error) {
 	_, err := url.ParseRequestURI(hookURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid Slack hook URL %s", hookURL)
+		return nil, fmt.Errorf("invalid Slack hook URL %s: '%w'", hookURL, err)
 	}
 
 	return &Slack{

--- a/internal/notifier/teams.go
+++ b/internal/notifier/teams.go
@@ -57,7 +57,7 @@ type MSTeamsField struct {
 func NewMSTeams(hookURL string, proxyURL string, certPool *x509.CertPool) (*MSTeams, error) {
 	_, err := url.ParseRequestURI(hookURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid MS Teams webhook URL %s", hookURL)
+		return nil, fmt.Errorf("invalid MS Teams webhook URL %s: '%w'", hookURL, err)
 	}
 
 	return &MSTeams{

--- a/internal/notifier/webex.go
+++ b/internal/notifier/webex.go
@@ -66,7 +66,7 @@ func NewWebex(hookURL, proxyURL string, certPool *x509.CertPool, channel string,
 
 	_, err := url.ParseRequestURI(hookURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid Webex hook URL %s", hookURL)
+		return nil, fmt.Errorf("invalid Webex hook URL %s: '%w'", hookURL, err)
 	}
 
 	return &Webex{


### PR DESCRIPTION
This pull request adds the error from parsing provider URLs to the returned error message.
This would be helpful in debugging issues and understanding why the URL might be invalid.

Ref: [discussion#2719](https://github.com/fluxcd/flux2/discussions/2719)

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>