### PR TITLE
Add context to Post function

### DIFF
--- a/internal/notifier/alertmanager.go
+++ b/internal/notifier/alertmanager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"net/url"
@@ -50,7 +51,7 @@ func NewAlertmanager(hookURL string, proxyURL string, certPool *x509.CertPool) (
 	}, nil
 }
 
-func (s *Alertmanager) Post(event events.Event) error {
+func (s *Alertmanager) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/alertmanager_test.go
+++ b/internal/notifier/alertmanager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -40,6 +41,6 @@ func TestAlertmanager_Post(t *testing.T) {
 	alertmanager, err := NewAlertmanager(ts.URL, "", nil)
 	require.NoError(t, err)
 
-	err = alertmanager.Post(testEvent())
+	err = alertmanager.Post(context.TODO(), testEvent())
 	require.NoError(t, err)
 }

--- a/internal/notifier/azure_devops.go
+++ b/internal/notifier/azure_devops.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/fluxcd/pkg/runtime/events"
 
@@ -78,7 +77,7 @@ func NewAzureDevOps(addr string, token string, certPool *x509.CertPool) (*AzureD
 }
 
 // Post Azure DevOps commit status
-func (a AzureDevOps) Post(event events.Event) error {
+func (a AzureDevOps) Post(ctx context.Context, event events.Event) error {
 	// Skip progressing events
 	if event.Reason == "Progressing" {
 		return nil
@@ -96,9 +95,6 @@ func (a AzureDevOps) Post(event events.Event) error {
 	if err != nil {
 		return err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
 
 	// Check if the exact status is already set
 	g := genre
@@ -130,7 +126,7 @@ func (a AzureDevOps) Post(event events.Event) error {
 	}
 
 	// Create a new status
-	_, err = a.Client.CreateCommitStatus(context.Background(), createArgs)
+	_, err = a.Client.CreateCommitStatus(ctx, createArgs)
 	if err != nil {
 		return fmt.Errorf("could not create commit status: %v", err)
 	}

--- a/internal/notifier/azure_eventhub.go
+++ b/internal/notifier/azure_eventhub.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/Azure/azure-amqp-common-go/v3/auth"
 	eventhub "github.com/Azure/azure-event-hubs-go/v3"
@@ -53,14 +52,11 @@ func NewAzureEventHub(endpointURL, token, eventHubNamespace string) (*AzureEvent
 }
 
 // Post all notification-controller messages to EventHub
-func (e *AzureEventHub) Post(event events.Event) error {
+func (e *AzureEventHub) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	eventBytes, err := json.Marshal(event)
 	if err != nil {

--- a/internal/notifier/bitbucket.go
+++ b/internal/notifier/bitbucket.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -80,7 +81,7 @@ func NewBitbucket(addr string, token string, certPool *x509.CertPool) (*Bitbucke
 }
 
 // Post Bitbucket commit status
-func (b Bitbucket) Post(event events.Event) error {
+func (b Bitbucket) Post(ctx context.Context, event events.Event) error {
 	// Skip progressing events
 	if event.Reason == "Progressing" {
 		return nil

--- a/internal/notifier/discord.go
+++ b/internal/notifier/discord.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"path"
@@ -56,7 +57,7 @@ func NewDiscord(hookURL string, proxyURL string, username string, channel string
 }
 
 // Post Discord message
-func (s *Discord) Post(event events.Event) error {
+func (s *Discord) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/discord_test.go
+++ b/internal/notifier/discord_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -45,6 +46,6 @@ func TestDiscord_Post(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, strings.HasSuffix(discord.URL, "/slack"))
 
-	err = discord.Post(testEvent())
+	err = discord.Post(context.TODO(), testEvent())
 	require.NoError(t, err)
 }

--- a/internal/notifier/forwarder.go
+++ b/internal/notifier/forwarder.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"net/url"
@@ -52,7 +53,7 @@ func NewForwarder(hookURL string, proxyURL string, headers map[string]string, ce
 	}, nil
 }
 
-func (f *Forwarder) Post(event events.Event) error {
+func (f *Forwarder) Post(ctx context.Context, event events.Event) error {
 	err := postMessage(f.URL, f.ProxyURL, f.CertPool, event, func(req *retryablehttp.Request) {
 		req.Header.Set(NotificationHeader, event.ReportingController)
 		for key, val := range f.Headers {

--- a/internal/notifier/forwarder_test.go
+++ b/internal/notifier/forwarder_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -48,6 +49,6 @@ func TestForwarder_Post(t *testing.T) {
 	forwarder, err := NewForwarder(ts.URL, "", headers, nil)
 	require.NoError(t, err)
 
-	err = forwarder.Post(testEvent())
+	err = forwarder.Post(context.TODO(), testEvent())
 	require.NoError(t, err)
 }

--- a/internal/notifier/github.go
+++ b/internal/notifier/github.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/fluxcd/pkg/runtime/events"
 
@@ -88,7 +87,7 @@ func NewGitHub(addr string, token string, certPool *x509.CertPool) (*GitHub, err
 }
 
 // Post Github commit status
-func (g *GitHub) Post(event events.Event) error {
+func (g *GitHub) Post(ctx context.Context, event events.Event) error {
 	// Skip progressing events
 	if event.Reason == "Progressing" {
 		return nil
@@ -113,9 +112,6 @@ func (g *GitHub) Post(event events.Event) error {
 		Context:     &name,
 		Description: &desc,
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
 
 	opts := &github.ListOptions{PerPage: 50}
 	statuses, _, err := g.Client.Repositories.ListStatuses(ctx, g.Owner, g.Repo, rev, opts)

--- a/internal/notifier/github_dispatch.go
+++ b/internal/notifier/github_dispatch.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/fluxcd/pkg/runtime/events"
 
@@ -89,7 +88,7 @@ func NewGitHubDispatch(addr string, token string, certPool *x509.CertPool) (*Git
 }
 
 // Post GitHub Repository Dispatch webhook
-func (g *GitHubDispatch) Post(event events.Event) error {
+func (g *GitHubDispatch) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil
@@ -97,9 +96,6 @@ func (g *GitHubDispatch) Post(event events.Event) error {
 
 	eventType := fmt.Sprintf("%s/%s.%s",
 		event.InvolvedObject.Kind, event.InvolvedObject.Name, event.InvolvedObject.Namespace)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
 
 	eventData, err := json.Marshal(event)
 	if err != nil {

--- a/internal/notifier/github_dispatch_test.go
+++ b/internal/notifier/github_dispatch_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,6 +56,6 @@ func TestGitHubDispatch_PostUpdate(t *testing.T) {
 
 	event := testEvent()
 	event.Metadata["commit_status"] = "update"
-	err = githubDispatch.Post(event)
+	err = githubDispatch.Post(context.TODO(), event)
 	require.NoError(t, err)
 }

--- a/internal/notifier/google_chat.go
+++ b/internal/notifier/google_chat.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -85,7 +86,7 @@ func NewGoogleChat(hookURL string, proxyURL string) (*GoogleChat, error) {
 }
 
 // Post Google Chat message
-func (s *GoogleChat) Post(event events.Event) error {
+func (s *GoogleChat) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/google_chat_test.go
+++ b/internal/notifier/google_chat_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -45,6 +46,6 @@ func TestGoogleChat_Post(t *testing.T) {
 	google_chat, err := NewGoogleChat(ts.URL, "")
 	require.NoError(t, err)
 
-	err = google_chat.Post(testEvent())
+	err = google_chat.Post(context.TODO(), testEvent())
 	require.NoError(t, err)
 }

--- a/internal/notifier/grafana.go
+++ b/internal/notifier/grafana.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"net/url"
@@ -60,7 +61,7 @@ func NewGrafana(URL string, proxyURL string, token string, certPool *x509.CertPo
 }
 
 // Post annotation
-func (g *Grafana) Post(event events.Event) error {
+func (g *Grafana) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/grafana_test.go
+++ b/internal/notifier/grafana_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -46,7 +47,7 @@ func TestGrafana_Post(t *testing.T) {
 		grafana, err := NewGrafana(ts.URL, "", "", nil, "", "")
 		require.NoError(t, err)
 
-		err = grafana.Post(testEvent())
+		err = grafana.Post(context.TODO(), testEvent())
 		assert.NoError(t, err)
 	})
 }

--- a/internal/notifier/lark.go
+++ b/internal/notifier/lark.go
@@ -1,6 +1,7 @@
 package notifier
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -60,7 +61,7 @@ func NewLark(address string) (*Lark, error) {
 	}, nil
 }
 
-func (l *Lark) Post(event events.Event) error {
+func (l *Lark) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/lark_test.go
+++ b/internal/notifier/lark_test.go
@@ -1,6 +1,7 @@
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -26,6 +27,6 @@ func TestLark_Post(t *testing.T) {
 	lark, err := NewLark(ts.URL)
 	require.NoError(t, err)
 
-	err = lark.Post(testEvent())
+	err = lark.Post(context.TODO(), testEvent())
 	require.NoError(t, err)
 }

--- a/internal/notifier/matrix.go
+++ b/internal/notifier/matrix.go
@@ -1,6 +1,7 @@
 package notifier
 
 import (
+	"context"
 	"crypto/sha1"
 	"crypto/x509"
 	"encoding/json"
@@ -39,7 +40,7 @@ func NewMatrix(serverURL, token, roomId string, certPool *x509.CertPool) (*Matri
 	}, nil
 }
 
-func (m *Matrix) Post(event events.Event) error {
+func (m *Matrix) Post(ctx context.Context, event events.Event) error {
 	txId, err := sha1sum(event)
 	if err != nil {
 		return fmt.Errorf("unable to generate unique tx id: %s", err)

--- a/internal/notifier/nop.go
+++ b/internal/notifier/nop.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package notifier
 
-import "github.com/fluxcd/pkg/runtime/events"
+import (
+	"context"
+
+	"github.com/fluxcd/pkg/runtime/events"
+)
 
 type NopNotifier struct{}
 
-func (n *NopNotifier) Post(event events.Event) error {
+func (n *NopNotifier) Post(ctx context.Context, event events.Event) error {
 	return nil
 }

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -17,9 +17,11 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
+
 	"github.com/fluxcd/pkg/runtime/events"
 )
 
 type Interface interface {
-	Post(event events.Event) error
+	Post(ctx context.Context, event events.Event) error
 }

--- a/internal/notifier/opsgenie.go
+++ b/internal/notifier/opsgenie.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -58,7 +59,7 @@ func NewOpsgenie(hookURL string, proxyURL string, certPool *x509.CertPool, token
 }
 
 // Post opsgenie alert message
-func (s *Opsgenie) Post(event events.Event) error {
+func (s *Opsgenie) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/opsgenie_test.go
+++ b/internal/notifier/opsgenie_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -40,6 +41,6 @@ func TestOpsgenie_Post(t *testing.T) {
 	opsgenie, err := NewOpsgenie(ts.URL, "", nil, "token")
 	require.NoError(t, err)
 
-	err = opsgenie.Post(testEvent())
+	err = opsgenie.Post(context.TODO(), testEvent())
 	require.NoError(t, err)
 }

--- a/internal/notifier/rocket.go
+++ b/internal/notifier/rocket.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -60,7 +61,7 @@ func NewRocket(hookURL string, proxyURL string, certPool *x509.CertPool, usernam
 }
 
 // Post Rocket message
-func (s *Rocket) Post(event events.Event) error {
+func (s *Rocket) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/rocket_test.go
+++ b/internal/notifier/rocket_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -42,6 +43,6 @@ func TestRocket_Post(t *testing.T) {
 	rocket, err := NewRocket(ts.URL, "", nil, "test", "test")
 	require.NoError(t, err)
 
-	err = rocket.Post(testEvent())
+	err = rocket.Post(context.TODO(), testEvent())
 	require.NoError(t, err)
 }

--- a/internal/notifier/sentry.go
+++ b/internal/notifier/sentry.go
@@ -58,7 +58,7 @@ func NewSentry(certPool *x509.CertPool, dsn string, environment string) (*Sentry
 }
 
 // Post event to Sentry
-func (s *Sentry) Post(event events.Event) error {
+func (s *Sentry) Post(ctx context.Context, event events.Event) error {
 	var sev *sentry.Event
 	// Send event to Sentry
 	switch event.Severity {

--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"net/url"
@@ -79,7 +80,7 @@ func NewSlack(hookURL string, proxyURL string, token string, certPool *x509.Cert
 }
 
 // Post Slack message
-func (s *Slack) Post(event events.Event) error {
+func (s *Slack) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/slack_test.go
+++ b/internal/notifier/slack_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -42,7 +43,7 @@ func TestSlack_Post(t *testing.T) {
 	slack, err := NewSlack(ts.URL, "", "", nil, "", "test")
 	require.NoError(t, err)
 
-	err = slack.Post(testEvent())
+	err = slack.Post(context.TODO(), testEvent())
 	require.NoError(t, err)
 }
 
@@ -52,6 +53,6 @@ func TestSlack_PostUpdate(t *testing.T) {
 
 	event := testEvent()
 	event.Metadata["commit_status"] = "update"
-	err = slack.Post(event)
+	err = slack.Post(context.TODO(), event)
 	require.NoError(t, err)
 }

--- a/internal/notifier/teams.go
+++ b/internal/notifier/teams.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"net/url"
@@ -68,7 +69,7 @@ func NewMSTeams(hookURL string, proxyURL string, certPool *x509.CertPool) (*MSTe
 }
 
 // Post MS Teams message
-func (s *MSTeams) Post(event events.Event) error {
+func (s *MSTeams) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/teams_test.go
+++ b/internal/notifier/teams_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -42,6 +43,6 @@ func TestTeams_Post(t *testing.T) {
 	teams, err := NewMSTeams(ts.URL, "", nil)
 	require.NoError(t, err)
 
-	err = teams.Post(testEvent())
+	err = teams.Post(context.TODO(), testEvent())
 	require.NoError(t, err)
 }

--- a/internal/notifier/telegram.go
+++ b/internal/notifier/telegram.go
@@ -1,6 +1,7 @@
 package notifier
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -25,7 +26,7 @@ func NewTelegram(channel, token string) (*Telegram, error) {
 	}, nil
 }
 
-func (t *Telegram) Post(event events.Event) error {
+func (t *Telegram) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/webex.go
+++ b/internal/notifier/webex.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"net/url"
@@ -96,7 +97,7 @@ func (s *Webex) CreateMarkdown(event *events.Event) string {
 }
 
 // Post Webex message
-func (s *Webex) Post(event events.Event) error {
+func (s *Webex) Post(ctx context.Context, event events.Event) error {
 	// Skip any update events
 	if isCommitStatus(event.Metadata, "update") {
 		return nil

--- a/internal/notifier/webex_test.go
+++ b/internal/notifier/webex_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -40,7 +41,7 @@ func TestWebex_Post(t *testing.T) {
 	webex, err := NewWebex(ts.URL, "", nil, "room", "token")
 	require.NoError(t, err)
 
-	err = webex.Post(testEvent())
+	err = webex.Post(context.TODO(), testEvent())
 	require.NoError(t, err)
 }
 
@@ -50,6 +51,6 @@ func TestWebex_PostUpdate(t *testing.T) {
 
 	event := testEvent()
 	event.Metadata["commit_status"] = "update"
-	err = webex.Post(event)
+	err = webex.Post(context.TODO(), event)
 	require.NoError(t, err)
 }

--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -63,7 +63,7 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 
 		cleanupMetadata(event)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 		defer cancel()
 
 		var allAlerts v1beta1.AlertList
@@ -265,7 +265,7 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 			}
 
 			go func(n notifier.Interface, e events.Event) {
-				if err := n.Post(e); err != nil {
+				if err := n.Post(ctx, e); err != nil {
 					maskedErrStr, maskErr := masktoken.MaskTokenFromString(err.Error(), token)
 					if maskErr != nil {
 						err = maskErr

--- a/tests/fuzz/alertmanager_fuzzer.go
+++ b/tests/fuzz/alertmanager_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func FuzzAlertmanager(data []byte) int {
 		return 0
 	}
 
-	_ = alertmanager.Post(event)
+	_ = alertmanager.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/azure_devops_fuzzer.go
+++ b/tests/fuzz/azure_devops_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -52,7 +53,7 @@ func FuzzAzureDevOps(data []byte) int {
 		return 0
 	}
 
-	_ = azureDevOps.Post(event)
+	_ = azureDevOps.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/bitbucket_fuzzer.go
+++ b/tests/fuzz/bitbucket_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -52,7 +53,7 @@ func FuzzBitbucket(data []byte) int {
 		return 0
 	}
 
-	_ = bitbucket.Post(event)
+	_ = bitbucket.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/discord_fuzzer.go
+++ b/tests/fuzz/discord_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -57,7 +58,7 @@ func FuzzDiscord(data []byte) int {
 		return 0
 	}
 
-	_ = discord.Post(event)
+	_ = discord.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/forwarder_fuzzer.go
+++ b/tests/fuzz/forwarder_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -49,7 +50,7 @@ func FuzzForwarder(data []byte) int {
 		return 0
 	}
 
-	_ = forwarder.Post(event)
+	_ = forwarder.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/github_fuzzer.go
+++ b/tests/fuzz/github_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -52,7 +53,7 @@ func FuzzGitHub(data []byte) int {
 		return 0
 	}
 
-	_ = github.Post(event)
+	_ = github.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/gitlab_fuzzer.go
+++ b/tests/fuzz/gitlab_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -52,7 +53,7 @@ func FuzzGitLab(data []byte) int {
 		return 0
 	}
 
-	_ = gitLab.Post(event)
+	_ = gitLab.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/google_chat_fuzzer.go
+++ b/tests/fuzz/google_chat_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func FuzzGoogleChat(data []byte) int {
 		return 0
 	}
 
-	_ = googlechat.Post(event)
+	_ = googlechat.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/lark_fuzzer.go
+++ b/tests/fuzz/lark_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func FuzzLark(data []byte) int {
 		return 0
 	}
 
-	_ = lark.Post(event)
+	_ = lark.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/matrix_fuzzer.go
+++ b/tests/fuzz/matrix_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -52,7 +53,7 @@ func FuzzMatrix(data []byte) int {
 		return 0
 	}
 
-	_ = matrix.Post(event)
+	_ = matrix.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/opsgenie_fuzzer.go
+++ b/tests/fuzz/opsgenie_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func FuzzOpsGenie(data []byte) int {
 		return 0
 	}
 
-	_ = opsgenie.Post(event)
+	_ = opsgenie.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/rocket_fuzzer.go
+++ b/tests/fuzz/rocket_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -57,7 +58,7 @@ func FuzzRocket(data []byte) int {
 		return 0
 	}
 
-	_ = rocket.Post(event)
+	_ = rocket.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/slack_fuzzer.go
+++ b/tests/fuzz/slack_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -62,7 +63,7 @@ func FuzzSlack(data []byte) int {
 		return 0
 	}
 
-	_ = slack.Post(event)
+	_ = slack.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/teams_fuzzer.go
+++ b/tests/fuzz/teams_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func FuzzMSTeams(data []byte) int {
 		return 0
 	}
 
-	_ = teams.Post(event)
+	_ = teams.Post(context.TODO(), event)
 
 	return 1
 }

--- a/tests/fuzz/webex_fuzzer.go
+++ b/tests/fuzz/webex_fuzzer.go
@@ -20,6 +20,7 @@ limitations under the License.
 package notifier
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func FuzzWebex(data []byte) int {
 		return 0
 	}
 
-	_ = webex.Post(event)
+	_ = webex.Post(context.TODO(), event)
 
 	return 1
 }


### PR DESCRIPTION
The change adds a context to the Post function. Most notifiers do not require a context as they just use HTTP requests, but those that import an SDK tend to do. By passing a context in the Post function new contributions do not have to guess on which context to use and how long the timeout should be.

This change also fixes some context issues, adding context to Gitlab and fixing Azure DevOps context.