### PR TITLE
Add extra tags to Grafana annotations

### DIFF
--- a/internal/notifier/grafana.go
+++ b/internal/notifier/grafana.go
@@ -73,6 +73,8 @@ func (g *Grafana) Post(ctx context.Context, event events.Event) error {
 	for k, v := range event.Metadata {
 		sfields = append(sfields, fmt.Sprintf("%s: %s", k, v))
 	}
+	sfields = append(sfields, fmt.Sprintf("name: %s", event.InvolvedObject.Name))
+	sfields = append(sfields, fmt.Sprintf("namespace: %s", event.InvolvedObject.Namespace))
 	payload := GraphitePayload{
 		When: event.Timestamp.Unix(),
 		Text: fmt.Sprintf("%s/%s.%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.InvolvedObject.Namespace),

--- a/internal/notifier/grafana_test.go
+++ b/internal/notifier/grafana_test.go
@@ -41,6 +41,8 @@ func TestGrafana_Post(t *testing.T) {
 			require.Equal(t, "flux", payload.Tags[0])
 			require.Equal(t, "source-controller", payload.Tags[1])
 			require.Equal(t, "test: metadata", payload.Tags[2])
+			require.Equal(t, "name: webapp", payload.Tags[3])
+			require.Equal(t, "namespace: gitops-system", payload.Tags[4])
 		}))
 		defer ts.Close()
 


### PR DESCRIPTION
This adds the name and namespace tags to Grafana annotations.

This makes it possible to use the Grafana provider when one has multiple Flux tenants writing to the same Grafana instance.