### PR TITLE
Fix context cancel defer for commit status updates

### DIFF
--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -265,6 +265,8 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 			}
 
 			go func(n notifier.Interface, e events.Event) {
+				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer cancel()
 				if err := n.Post(ctx, e); err != nil {
 					maskedErrStr, maskErr := masktoken.MaskTokenFromString(err.Error(), token)
 					if maskErr != nil {


### PR DESCRIPTION
This change fixes the cancel defer so that it is not cancelled before the go routine can run. The issue right now is that the Post function is cancelled prematurely. 

Fixes #406 