### PR TITLE
Be able to exclude event names in Alert exclusionList

### DIFF
--- a/api/v1beta1/alert_types.go
+++ b/api/v1beta1/alert_types.go
@@ -42,7 +42,7 @@ type AlertSpec struct {
 	// +required
 	EventSources []CrossNamespaceObjectReference `json:"eventSources"`
 
-	// A list of Golang regular expressions to be used for excluding messages.
+	// A list of Golang regular expressions to be used for excluding messages and names.
 	// +optional
 	ExclusionList []string `json:"exclusionList,omitempty"`
 

--- a/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
@@ -103,7 +103,7 @@ spec:
                 type: array
               exclusionList:
                 description: A list of Golang regular expressions to be used for excluding
-                  messages.
+                  messages and names.
                 items:
                   type: string
                 type: array

--- a/controllers/event_handling_test.go
+++ b/controllers/event_handling_test.go
@@ -141,6 +141,7 @@ func TestEventHandler(t *testing.T) {
 			ExclusionList: []string{
 				"doesnotoccur", // not intended to match
 				"excluded",
+				"name-drop",
 			},
 		},
 	}
@@ -227,9 +228,17 @@ func TestEventHandler(t *testing.T) {
 			forwarded: false,
 		},
 		{
-			name: "drops event that is matched by exclusion",
+			name: "drops event that is matched by exclusion with message",
 			modifyEventFunc: func(e events.Event) events.Event {
 				e.Message = "this is excluded"
+				return e
+			},
+			forwarded: false,
+		},
+		{
+			name: "drops event that is matched by exclusion with name",
+			modifyEventFunc: func(e events.Event) events.Event {
+				e.InvolvedObject.Name = "name-drop"
 				return e
 			},
 			forwarded: false,

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -120,7 +120,7 @@ If set to &lsquo;info&rsquo; no events will be filtered.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>A list of Golang regular expressions to be used for excluding messages.</p>
+<p>A list of Golang regular expressions to be used for excluding messages and names.</p>
 </td>
 </tr>
 <tr>
@@ -565,7 +565,7 @@ If set to &lsquo;info&rsquo; no events will be filtered.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>A list of Golang regular expressions to be used for excluding messages.</p>
+<p>A list of Golang regular expressions to be used for excluding messages and names.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta1/alert.md
+++ b/docs/spec/v1beta1/alert.md
@@ -21,7 +21,7 @@ type AlertSpec struct {
 	// +required
 	EventSources []CrossNamespaceObjectReference `json:"eventSources"`
 
-	// A list of Golang regular expressions to be used for excluding messages.
+	// A list of Golang regular expressions to be used for excluding messages and names.
 	// +optional
 	ExclusionList []string `json:"exclusionList,omitempty"`
 

--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -88,7 +88,7 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 			if len(alert.Spec.ExclusionList) > 0 {
 				for _, exp := range alert.Spec.ExclusionList {
 					if r, err := regexp.Compile(exp); err == nil {
-						if r.Match([]byte(event.Message)) {
+						if r.Match([]byte(event.Message)) || r.Match([]byte(event.InvolvedObject.Name)) {
 							continue each_alert
 						}
 					} else {


### PR DESCRIPTION
This adds the possibility to exclude alerts based on event name

Fixes https://github.com/fluxcd/notification-controller/issues/418