### PR TITLE
api: add custom validation for v1.Duration types

### DIFF
--- a/api/v1beta1/provider_types.go
+++ b/api/v1beta1/provider_types.go
@@ -49,6 +49,8 @@ type ProviderSpec struct {
 	Address string `json:"address,omitempty"`
 
 	// Timeout for sending alerts to the provider.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -83,6 +83,7 @@ spec:
                 type: boolean
               timeout:
                 description: Timeout for sending alerts to the provider.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                 type: string
               type:
                 description: Type of provider


### PR DESCRIPTION
To solve discrepancies between parsing versus validation.

xref: https://github.com/kubernetes/apimachinery/issues/131