### PR TITLE
Add "generic-hmac" Provider

### DIFF
--- a/api/v1beta1/provider_types.go
+++ b/api/v1beta1/provider_types.go
@@ -30,7 +30,7 @@ const (
 // ProviderSpec defines the desired state of Provider
 type ProviderSpec struct {
 	// Type of provider
-	// +kubebuilder:validation:Enum=slack;discord;msteams;rocket;generic;github;gitlab;bitbucket;azuredevops;googlechat;webex;sentry;azureeventhub;telegram;lark;matrix;opsgenie;alertmanager;grafana;githubdispatch;
+	// +kubebuilder:validation:Enum=slack;discord;msteams;rocket;generic;generic-hmac;github;gitlab;bitbucket;azuredevops;googlechat;webex;sentry;azureeventhub;telegram;lark;matrix;opsgenie;alertmanager;grafana;githubdispatch;
 	// +required
 	Type string `json:"type"`
 
@@ -78,6 +78,7 @@ type ProviderSpec struct {
 
 const (
 	GenericProvider        string = "generic"
+	GenericHMACProvider    string = "generic-hmac"
 	SlackProvider          string = "slack"
 	GrafanaProvider        string = "grafana"
 	DiscordProvider        string = "discord"

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -92,6 +92,7 @@ spec:
                 - msteams
                 - rocket
                 - generic
+                - generic-hmac
                 - github
                 - gitlab
                 - bitbucket

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -56,7 +56,9 @@ func (f Factory) Notifier(provider string) (Interface, error) {
 	var err error
 	switch provider {
 	case v1beta1.GenericProvider:
-		n, err = NewForwarder(f.URL, f.ProxyURL, f.Headers, f.CertPool)
+		n, err = NewForwarder(f.URL, f.ProxyURL, f.Headers, f.CertPool, nil)
+	case v1beta1.GenericHMACProvider:
+		n, err = NewForwarder(f.URL, f.ProxyURL, f.Headers, f.CertPool, []byte(f.Token))
 	case v1beta1.SlackProvider:
 		n, err = NewSlack(f.URL, f.ProxyURL, f.Token, f.CertPool, f.Username, f.Channel)
 	case v1beta1.DiscordProvider:

--- a/internal/notifier/forwarder_test.go
+++ b/internal/notifier/forwarder_test.go
@@ -25,42 +25,124 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	"github.com/fluxcd/pkg/runtime/events"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/require"
 )
 
+func TestForwarder_New(t *testing.T) {
+	tests := []struct {
+		name    string
+		hmacKey []byte
+		err     bool
+	}{
+		{
+			name:    "nil HMAC key passes",
+			hmacKey: nil,
+			err:     false,
+		},
+		{
+			name:    "empty HMAC key fails",
+			hmacKey: []byte{},
+			err:     true,
+		},
+		{
+			name:    "happy path with HMAC key from empty string",
+			hmacKey: []byte(""),
+			err:     true,
+		},
+		{
+			name:    "non-empty HMAC key adds signature header",
+			hmacKey: []byte("7152fed34dd6149a7c75a276c510da27cb6f82b0"),
+			err:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewForwarder("http://example.org", "", nil, nil, tt.hmacKey)
+			if tt.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestForwarder_Post(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+	tests := []struct {
+		name       string
+		hmacKey    []byte
+		hmacHeader string
+		xSigHeader string
+	}{
+		{
+			name: "happy path with nil HMAC key",
+		},
+		{
+			name:       "preset X-Signature header should persist",
+			xSigHeader: "should be preserved",
+		},
+		{
+			name:       "non-empty HMAC key adds signature header",
+			hmacKey:    []byte("7152fed34dd6149a7c75a276c510da27cb6f82b0"),
+			hmacHeader: "sha256=65b018549b1254e7226d1c08f9567ee45bc9de0fc4e7b1a40253f9a018b08be7",
+			xSigHeader: "should be overwritten with actual signature",
+		},
+	}
 
-		require.Equal(t, "source-controller", r.Header.Get("gotk-component"))
-		require.Equal(t, "token", r.Header.Get("Authorization"))
-		var payload = events.Event{}
-		err = json.Unmarshal(b, &payload)
-		require.NoError(t, err)
-		require.Equal(t, "webapp", payload.InvolvedObject.Name)
-		require.Equal(t, "metadata", payload.Metadata["test"])
-	}))
-	defer ts.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
 
-	headers := make(map[string]string)
-	headers["Authorization"] = "token"
-	forwarder, err := NewForwarder(ts.URL, "", headers, nil)
-	require.NoError(t, err)
+				require.Equal(t, "source-controller", r.Header.Get("gotk-component"))
+				require.Equal(t, "token", r.Header.Get("Authorization"))
+				if tt.hmacHeader == "" {
+					sigHdrVal, ok := r.Header["X-Signature"]
+					if tt.xSigHeader == "" {
+						require.Equal(t, false, ok, "expected signature header to be absent but it was present")
+					} else {
+						require.Equal(t, []string{tt.xSigHeader}, sigHdrVal)
+					}
+				} else {
+					require.Equal(t, tt.hmacHeader, r.Header.Get("X-Signature"))
+				}
+				var payload = events.Event{}
+				err = json.Unmarshal(b, &payload)
+				require.NoError(t, err)
+				require.Equal(t, "webapp", payload.InvolvedObject.Name)
+				require.Equal(t, "metadata", payload.Metadata["test"])
+			}))
+			defer ts.Close()
 
-	err = forwarder.Post(context.TODO(), testEvent())
-	require.NoError(t, err)
+			headers := make(map[string]string)
+			headers["Authorization"] = "token"
+			if tt.xSigHeader != "" {
+				headers["X-Signature"] = tt.xSigHeader
+			}
+			forwarder, err := NewForwarder(ts.URL, "", headers, nil, tt.hmacKey)
+			require.NoError(t, err)
+
+			ev := testEvent()
+			ev.Timestamp = metav1.NewTime(time.Unix(1664520029, 0))
+			err = forwarder.Post(context.TODO(), ev)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func Fuzz_Forwarder(f *testing.F) {
-	f.Add("", []byte{}, []byte{})
+	f.Add("", []byte{}, []byte{}, []byte{})
 
 	f.Fuzz(func(t *testing.T,
-		urlSuffix string, seed, response []byte) {
+		urlSuffix string, seed, response, hmacKey []byte) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write(response)
 			io.Copy(io.Discard, r.Body)
@@ -74,7 +156,7 @@ func Fuzz_Forwarder(f *testing.F) {
 		header := make(map[string]string)
 		_ = fuzz.NewConsumer(seed).FuzzMap(&header)
 
-		forwarder, err := NewForwarder(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", header, &cert)
+		forwarder, err := NewForwarder(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", header, &cert, hmacKey)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
This commit adds the "generic-hmac" Provider type for authenticating
webhook requests coming from notification-controller. I extended the
`Forwarder` notifier to accept an optional key used for generating the
HMAC. If the key is nil or empty no HMAC header is generated and the
forwarder behaves as before. If it is provided an `X-Signature` HTTP
header is added to the request carrying the HMAC.

I transformed the `TestForwarder_Post` test into a table-driven test
so that we can use the same setup and testing code for testing HMAC
and non-HMAC forwarder instances.

The Flux CLI will support this new type automatically as it doesn't validate the given type by itself (this is done by the API server using the CRD spec.

closes #99
