### PR TITLE
Prepend spec.summary to the github status message

### DIFF
--- a/internal/notifier/github.go
+++ b/internal/notifier/github.go
@@ -107,6 +107,13 @@ func (g *GitHub) Post(ctx context.Context, event events.Event) error {
 	}
 	name, desc := formatNameAndDescription(event)
 
+	// prepend summary to generated name - every reconciller will be writing it's own report
+	summary := event.Metadata["summary"]
+	if len(summary) > 0 {
+		name = fmt.Sprintf("%s/%s", summary, name)
+	}
+
+	
 	status := &github.RepoStatus{
 		State:       &state,
 		Context:     &name,


### PR DESCRIPTION
Prepend Alert: spec.summary to the name of github notification.

I would like to use Flux notification to github which will show the badge on successfull/unsuccessfull reconciliation.
But I would like to modify message and include name of the region which was able to apply changes.

Currently Flux notification controller does not take into account configured summary of the alert.
By default if there is no summary in the metadata it will generate default status message.

if summary is provided Notifications controller will prepend it to the name of status: by doing this multiple regions can report to the same status in Github. 