### PR TITLE
receiver: Use new ServeMux

### DIFF
--- a/internal/server/receiver_server.go
+++ b/internal/server/receiver_server.go
@@ -50,7 +50,7 @@ func NewReceiverServer(port string, logger logr.Logger, kubeClient client.Client
 
 // ListenAndServe starts the HTTP server on the specified port
 func (s *ReceiverServer) ListenAndServe(stopCh <-chan struct{}, mdlw middleware.Middleware) {
-	mux := http.DefaultServeMux
+	mux := http.NewServeMux()
 	mux.Handle("/hook/", http.HandlerFunc(s.handlePayload()))
 	h := std.Handler("", mdlw, mux)
 	srv := &http.Server{


### PR DESCRIPTION
Receiver should use its own ServeMux.

Related to https://github.com/fluxcd/notification-controller/issues/449