### PR TITLE
Fix panic when upgrading to v1beta2

### DIFF
--- a/api/v1beta2/provider_types.go
+++ b/api/v1beta2/provider_types.go
@@ -174,6 +174,16 @@ func (in *Provider) GetTimeout() time.Duration {
 	return duration
 }
 
+// GetInterval returns the interval value with a default of 10m for this Provider.
+func (in *Provider) GetInterval() time.Duration {
+	duration := 10 * time.Minute
+	if in.Spec.Interval != nil {
+		duration = in.Spec.Interval.Duration
+	}
+
+	return duration
+}
+
 // GetRequeueAfter returns the duration after which the Provider must be
 // reconciled again.
 func (in *Provider) GetRequeueAfter() time.Duration {

--- a/api/v1beta2/receiver_types.go
+++ b/api/v1beta2/receiver_types.go
@@ -19,6 +19,7 @@ package v1beta2
 import (
 	"crypto/sha256"
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -114,6 +115,16 @@ func (in *Receiver) SetConditions(conditions []metav1.Condition) {
 func (in *Receiver) GetWebhookPath(token string) string {
 	digest := sha256.Sum256([]byte(token + in.GetName() + in.GetNamespace()))
 	return fmt.Sprintf("%s%x", ReceiverWebhookPath, digest)
+}
+
+// GetInterval returns the interval value with a default of 10m for this Receiver.
+func (in *Receiver) GetInterval() time.Duration {
+	duration := 10 * time.Minute
+	if in.Spec.Interval != nil {
+		duration = in.Spec.Interval.Duration
+	}
+
+	return duration
 }
 
 // +genclient

--- a/controllers/provider_controller.go
+++ b/controllers/provider_controller.go
@@ -122,7 +122,7 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		// Log and emit success event.
 		if retErr == nil && conditions.IsReady(obj) {
 			msg := fmt.Sprintf("Reconciliation finished, next run in %s",
-				obj.Spec.Interval.Duration.String())
+				obj.GetInterval().String())
 			log.Info(msg)
 			r.Event(obj, corev1.EventTypeNormal, meta.SucceededReason, msg)
 		}
@@ -169,7 +169,7 @@ func (r *ProviderReconciler) reconcile(ctx context.Context, obj *apiv1.Provider)
 
 	conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, apiv1.InitializedReason)
 
-	return ctrl.Result{RequeueAfter: obj.Spec.Interval.Duration}, nil
+	return ctrl.Result{RequeueAfter: obj.GetInterval()}, nil
 }
 
 func (r *ProviderReconciler) validateURLs(provider *apiv1.Provider) error {

--- a/controllers/receiver_controller.go
+++ b/controllers/receiver_controller.go
@@ -119,7 +119,7 @@ func (r *ReceiverReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 
 		// Log and emit success event.
 		if retErr == nil && conditions.IsReady(obj) {
-			msg := fmt.Sprintf("Reconciliation finished, next run in %s", obj.Spec.Interval.Duration.String())
+			msg := fmt.Sprintf("Reconciliation finished, next run in %s", obj.GetInterval().String())
 			log.Info(msg)
 			r.Event(obj, corev1.EventTypeNormal, meta.SucceededReason, msg)
 		}
@@ -172,7 +172,7 @@ func (r *ReceiverReconciler) reconcile(ctx context.Context, obj *apiv1.Receiver)
 		ctrl.LoggerFrom(ctx).Info(msg)
 	}
 
-	return ctrl.Result{RequeueAfter: obj.Spec.Interval.Duration}, nil
+	return ctrl.Result{RequeueAfter: obj.GetInterval()}, nil
 }
 
 // patch updates the object status, conditions and finalizers.


### PR DESCRIPTION
The Kubernetes conversion webhook doesn't set the default value for the newly added `interval` field, to avoid controller panic, we set the default in code.