### PR TITLE
fix secret name in example

### DIFF
--- a/docs/spec/v1beta2/providers.md
+++ b/docs/spec/v1beta2/providers.md
@@ -390,7 +390,7 @@ metadata:
 spec:
   type: msteams
   secretRef:
-    name: slack-webhook
+    name: msteams-webhook
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
The msteams webhook example had an incorrect secret name, probably from copy-pasting.