### PR TITLE
un-document receivers.spec.resources.matchLabels

### DIFF
--- a/api/v1beta2/reference_types.go
+++ b/api/v1beta2/reference_types.go
@@ -29,7 +29,6 @@ type CrossNamespaceObjectReference struct {
 	Kind string `json:"kind,omitempty"`
 
 	// Name of the referent.
-	// If multiple resources are targeted `*` may be set.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=53
 	// +required
@@ -45,7 +44,6 @@ type CrossNamespaceObjectReference struct {
 	// MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
 	// map is equivalent to an element of matchExpressions, whose key field is "key", the
 	// operator is "In", and the values array contains only "value". The requirements are ANDed.
-	// MatchLabels requires the name to be set to `*`.
 	// +optional
 	MatchLabels map[string]string `json:"matchLabels,omitempty"`
 }

--- a/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
@@ -279,11 +279,10 @@ spec:
                         {key,value} in the matchLabels map is equivalent to an element
                         of matchExpressions, whose key field is "key", the operator
                         is "In", and the values array contains only "value". The requirements
-                        are ANDed. MatchLabels requires the name to be set to `*`.
+                        are ANDed.
                       type: object
                     name:
-                      description: Name of the referent. If multiple resources are
-                        targeted `*` may be set.
+                      description: Name of the referent.
                       maxLength: 53
                       minLength: 1
                       type: string

--- a/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
@@ -288,11 +288,10 @@ spec:
                         {key,value} in the matchLabels map is equivalent to an element
                         of matchExpressions, whose key field is "key", the operator
                         is "In", and the values array contains only "value". The requirements
-                        are ANDed. MatchLabels requires the name to be set to `*`.
+                        are ANDed.
                       type: object
                     name:
-                      description: Name of the referent. If multiple resources are
-                        targeted `*` may be set.
+                      description: Name of the referent.
                       maxLength: 53
                       minLength: 1
                       type: string

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -741,8 +741,7 @@ string
 </em>
 </td>
 <td>
-<p>Name of the referent.
-If multiple resources are targeted <code>*</code> may be set.</p>
+<p>Name of the referent.</p>
 </td>
 </tr>
 <tr>
@@ -768,8 +767,7 @@ map[string]string
 <em>(Optional)</em>
 <p>MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
 map is equivalent to an element of matchExpressions, whose key field is &ldquo;key&rdquo;, the
-operator is &ldquo;In&rdquo;, and the values array contains only &ldquo;value&rdquo;. The requirements are ANDed.
-MatchLabels requires the name to be set to <code>*</code>.</p>
+operator is &ldquo;In&rdquo;, and the values array contains only &ldquo;value&rdquo;. The requirements are ANDed.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/spec/v1beta2/receivers.md
+++ b/docs/spec/v1beta2/receivers.md
@@ -635,36 +635,9 @@ A resource entry contains the following fields:
   `GitRepository`, `Kustomization`, `HelmRelease`, `HelmChart`,
   `HelmRepository`, `ImageRepository`, `ImagePolicy`, `ImageUpdateAutomation`
   and `OCIRepository`.
-- `name`: The Flux Custom Resource `.metadata.name` or it can be set to '*' wildcard(when `matchLabels` is specified)
+- `name`: The Flux Custom Resource `.metadata.name`.
 - `namespace` (Optional): The Flux Custom Resource `.metadata.namespace`.
   When not specified, the Receiver's `.metadata.namespace` is used instead.
-- `matchLabels` (Optional): Annotate Flux Custom Resources with specific labels.
-   The `name` field must be set to '*' when using `matchLabels`
-
-#### Annotate objects by name
-
-To annotate single Flux object, set the `kind`, `name` and `namespace`:
-
-```yaml
-resources:
-  - apiVersion: image.toolkit.fluxcd.io/v1beta1
-    kind: ImageRepository
-    name: podinfo
-```
-
-#### Annotate objects by label
-
-To annotate Flux objects of a particular kind with specific labels:
-
-```yaml
-resources:
-  - apiVersion: image.toolkit.fluxcd.io/v1beta1
-    kind: ImageRepository
-    name: "*"
-    matchLabels:
-      app: podinfo
-```
-
 
 **Note:** Cross-namespace references [can be disabled for security
 reasons](#disabling-cross-namespace-selectors).


### PR DESCRIPTION
This has been introduced in #482 but we actually want this feature to only be available in v1 of the API. A follow-up PR will re-add this to the v1 API.
