### PR TITLE
Allow wildcard value for namespaces in Alert eventSources

### DIFF
--- a/docs/spec/v1beta2/alerts.md
+++ b/docs/spec/v1beta2/alerts.md
@@ -142,6 +142,19 @@ eventSources:
     namespace: apps
 ```
 
+#### Select objects from all namespaces
+
+The `*` wildcard can be used to select events issued by Flux objects from any `namespace`:
+
+```yaml
+eventSources:
+  - kind: HelmRelease
+    name: 'service1'
+    namespace: '*'
+```
+
+It requires to have cross-namespace references enabled for the controller.
+
 #### Select objects by label
 
 To select events issued by all Flux objects of a particular `kind` with specific `labels`:

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/ktrysmt/go-bitbucket v0.9.55
 	github.com/microsoft/azure-devops-go-api/azuredevops/v6 v6.0.1
 	github.com/onsi/gomega v1.27.2
+	github.com/prometheus/client_golang v1.14.0
 	github.com/sethvargo/go-limiter v0.7.2
 	github.com/slok/go-http-metrics v0.10.0
 	github.com/spf13/pflag v1.0.5
@@ -110,7 +111,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/internal/controllers/alert_controller_test.go
+++ b/internal/controllers/alert_controller_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/fluxcd/pkg/ssa"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sethvargo/go-limiter/memorystore"
 	prommetrics "github.com/slok/go-http-metrics/metrics/prometheus"
 	"github.com/slok/go-http-metrics/middleware"
@@ -169,9 +170,12 @@ func TestAlertReconciler_EventHandler(t *testing.T) {
 	)
 	g.Expect(createNamespace(namespace)).NotTo(HaveOccurred(), "failed to create test namespace")
 
+	reg := prometheus.NewRegistry()
+
 	eventMdlw := middleware.New(middleware.Config{
 		Recorder: prommetrics.NewRecorder(prommetrics.Config{
-			Prefix: "gotk_event",
+			Prefix:   "gotk_event",
+			Registry: reg,
 		}),
 	})
 
@@ -435,9 +439,12 @@ func TestAlertReconciler_EventHandler_CrossNamespaceRefs(t *testing.T) {
 	)
 	g.Expect(createNamespace(namespace)).NotTo(HaveOccurred(), "failed to create test namespace")
 
+	reg := prometheus.NewRegistry()
+
 	eventMdlw := middleware.New(middleware.Config{
 		Recorder: prommetrics.NewRecorder(prommetrics.Config{
-			Prefix: "gotk_event",
+			Prefix:   "gotk_event",
+			Registry: reg,
 		}),
 	})
 

--- a/internal/controllers/alert_controller_test.go
+++ b/internal/controllers/alert_controller_test.go
@@ -271,6 +271,11 @@ func TestAlertReconciler_EventHandler(t *testing.T) {
 					Name:      "*",
 					Namespace: "test",
 				},
+				{
+					Kind:      "Kustomization",
+					Name:      "testwildcardnamespace",
+					Namespace: "*",
+				},
 			},
 			ExclusionList: []string{
 				"doesnotoccur", // not intended to match
@@ -374,6 +379,17 @@ func TestAlertReconciler_EventHandler(t *testing.T) {
 				e.InvolvedObject.Kind = "Kustomization"
 				e.InvolvedObject.Name = "test"
 				e.InvolvedObject.Namespace = namespace
+				e.Message = "test"
+				return e
+			},
+			forwarded: true,
+		},
+		{
+			name: "forwards events when namespace wildcard is used",
+			modifyEventFunc: func(e eventv1.Event) eventv1.Event {
+				e.InvolvedObject.Kind = "Kustomization"
+				e.InvolvedObject.Name = "testwildcardnamespace"
+				e.InvolvedObject.Namespace = "test-" + randStringRunes(5)
 				e.Message = "test"
 				return e
 			},

--- a/internal/controllers/alert_controller_test.go
+++ b/internal/controllers/alert_controller_test.go
@@ -267,6 +267,11 @@ func TestAlertReconciler_EventHandler(t *testing.T) {
 					Name:      "*",
 					Namespace: "test",
 				},
+				{
+					Kind:      "Kustomization",
+					Name:      "testwildcardnamespace",
+					Namespace: "*",
+				},
 			},
 			ExclusionList: []string{
 				"doesnotoccur", // not intended to match
@@ -370,6 +375,17 @@ func TestAlertReconciler_EventHandler(t *testing.T) {
 				e.InvolvedObject.Kind = "Kustomization"
 				e.InvolvedObject.Name = "test"
 				e.InvolvedObject.Namespace = namespace
+				e.Message = "test"
+				return e
+			},
+			forwarded: true,
+		},
+		{
+			name: "forwards events when namespace wildcard is used",
+			modifyEventFunc: func(e eventv1.Event) eventv1.Event {
+				e.InvolvedObject.Kind = "Kustomization"
+				e.InvolvedObject.Name = "testwildcardnamespace"
+				e.InvolvedObject.Namespace = "test-" + randStringRunes(5)
 				e.Message = "test"
 				return e
 			},

--- a/internal/controllers/alert_controller_test.go
+++ b/internal/controllers/alert_controller_test.go
@@ -271,11 +271,6 @@ func TestAlertReconciler_EventHandler(t *testing.T) {
 					Name:      "*",
 					Namespace: "test",
 				},
-				{
-					Kind:      "Kustomization",
-					Name:      "testwildcardnamespace",
-					Namespace: "*",
-				},
 			},
 			ExclusionList: []string{
 				"doesnotoccur", // not intended to match
@@ -379,17 +374,6 @@ func TestAlertReconciler_EventHandler(t *testing.T) {
 				e.InvolvedObject.Kind = "Kustomization"
 				e.InvolvedObject.Name = "test"
 				e.InvolvedObject.Namespace = namespace
-				e.Message = "test"
-				return e
-			},
-			forwarded: true,
-		},
-		{
-			name: "forwards events when namespace wildcard is used",
-			modifyEventFunc: func(e eventv1.Event) eventv1.Event {
-				e.InvolvedObject.Kind = "Kustomization"
-				e.InvolvedObject.Name = "testwildcardnamespace"
-				e.InvolvedObject.Namespace = "test-" + randStringRunes(5)
 				e.Message = "test"
 				return e
 			},

--- a/internal/controllers/alert_controller_test.go
+++ b/internal/controllers/alert_controller_test.go
@@ -435,7 +435,7 @@ func TestAlertReconciler_EventHandler_CrossNamespaceRefs(t *testing.T) {
 	var (
 		namespace = "events-" + randStringRunes(5)
 		req       *http.Request
-		provider  *apiv1.Provider
+		provider  *apiv1beta2.Provider
 	)
 	g.Expect(createNamespace(namespace)).NotTo(HaveOccurred(), "failed to create test namespace")
 
@@ -470,19 +470,19 @@ func TestAlertReconciler_EventHandler_CrossNamespaceRefs(t *testing.T) {
 		Name:      fmt.Sprintf("provider-%s", randStringRunes(5)),
 		Namespace: namespace,
 	}
-	provider = &apiv1.Provider{
+	provider = &apiv1beta2.Provider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      providerKey.Name,
 			Namespace: providerKey.Namespace,
 		},
-		Spec: apiv1.ProviderSpec{
+		Spec: apiv1beta2.ProviderSpec{
 			Type:    "generic",
 			Address: rcvServer.URL,
 		},
 	}
 	g.Expect(k8sClient.Create(context.Background(), provider)).To(Succeed())
 	g.Eventually(func() bool {
-		var obj apiv1.Provider
+		var obj apiv1beta2.Provider
 		g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(provider), &obj))
 		return conditions.IsReady(&obj)
 	}, 30*time.Second, time.Second).Should(BeTrue())
@@ -508,12 +508,12 @@ func TestAlertReconciler_EventHandler_CrossNamespaceRefs(t *testing.T) {
 		Namespace: namespace,
 	}
 
-	alert := &apiv1.Alert{
+	alert := &apiv1beta2.Alert{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      alertKey.Name,
 			Namespace: alertKey.Namespace,
 		},
-		Spec: apiv1.AlertSpec{
+		Spec: apiv1beta2.AlertSpec{
 			ProviderRef: meta.LocalObjectReference{
 				Name: providerKey.Name,
 			},
@@ -556,7 +556,7 @@ func TestAlertReconciler_EventHandler_CrossNamespaceRefs(t *testing.T) {
 
 	// wait for controller to mark the alert as ready
 	g.Eventually(func() bool {
-		var obj apiv1.Alert
+		var obj apiv1beta2.Alert
 		g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(alert), &obj))
 		return conditions.IsReady(&obj)
 	}, 30*time.Second, time.Second).Should(BeTrue())

--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -288,7 +288,7 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *EventServer) eventMatchesAlert(ctx context.Context, event *eventv1.Event, source apiv1.CrossNamespaceObjectReference, severity string) bool {
-	if event.InvolvedObject.Namespace == source.Namespace && event.InvolvedObject.Kind == source.Kind || source.Namespace == "*" {
+	if (event.InvolvedObject.Namespace == source.Namespace || source.Namespace == "*") && event.InvolvedObject.Kind == source.Kind {
 		if event.Severity == severity || severity == eventv1.EventSeverityInfo {
 			labelMatch := true
 			if source.Name == "*" && source.MatchLabels != nil {

--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -288,7 +288,7 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *EventServer) eventMatchesAlert(ctx context.Context, event *eventv1.Event, source apiv1.CrossNamespaceObjectReference, severity string) bool {
-	if event.InvolvedObject.Namespace == source.Namespace && event.InvolvedObject.Kind == source.Kind {
+	if event.InvolvedObject.Namespace == source.Namespace && event.InvolvedObject.Kind == source.Kind || source.Namespace == "*" {
 		if event.Severity == severity || severity == eventv1.EventSeverityInfo {
 			labelMatch := true
 			if source.Name == "*" && source.MatchLabels != nil {


### PR DESCRIPTION
Allow wildcard value for namespaces in Alert eventSources.

Fix: https://github.com/fluxcd/notification-controller/issues/71

At the moment we have to create a list of all HelmRelease objects, for example, in the `eventSources` section to be able to get notifications about them. We also need to update the list whenever a new object is added. That requires lots of effort. It seems that the best way is to allow wildcards for namespaces.

How the Alert `eventSources` definition looks now:

```yaml
  eventSources:
    - kind: HelmRelease
      name: '*'
      namespace: 'service1'
    - kind: HelmRelease
      name: '*'
      namespace: 'service2'
...
    - kind: HelmRelease
      name: '*'
      namespace: 'service99'
```

How it would be after the change:

```yaml
  eventSources:
    - kind: HelmRelease
      name: '*'
      namespace: '*'
```