### PR TITLE
index receivers using webhook path as key

### DIFF
--- a/internal/controllers/receiver_controller.go
+++ b/internal/controllers/receiver_controller.go
@@ -41,6 +41,7 @@ import (
 	"github.com/fluxcd/pkg/runtime/predicates"
 
 	apiv1 "github.com/fluxcd/notification-controller/api/v1"
+	"github.com/fluxcd/notification-controller/internal/server"
 )
 
 // ReceiverReconciler reconciles a Receiver object
@@ -62,6 +63,12 @@ func (r *ReceiverReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ReceiverReconciler) SetupWithManagerAndOptions(mgr ctrl.Manager, opts ReceiverReconcilerOptions) error {
+	// This index is used to list Receivers by their webhook path after the receiver server
+	// gets a request.
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &apiv1.Receiver{},
+		server.WebhookPathIndexKey, server.IndexReceiverWebhookPath); err != nil {
+		return err
+	}
 	recoverPanic := true
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1.Receiver{}, builder.WithPredicates(

--- a/internal/controllers/receiver_controller_test.go
+++ b/internal/controllers/receiver_controller_test.go
@@ -198,7 +198,9 @@ func TestReceiverReconciler_EventHandler(t *testing.T) {
 	timeout := 30 * time.Second
 	resultR := &apiv1.Receiver{}
 
-	receiverServer := server.NewReceiverServer("127.0.0.1:56788", logf.Log, k8sClient)
+	// Use the client from the manager as the server handler needs to list objects from the cache
+	// which the "live" k8s client does not have access to.
+	receiverServer := server.NewReceiverServer("127.0.0.1:56788", logf.Log, testEnv.GetClient())
 	receiverMdlw := middleware.New(middleware.Config{
 		Recorder: prommetrics.NewRecorder(prommetrics.Config{
 			Prefix: "gotk_receiver",

--- a/internal/server/receiver_handler_test.go
+++ b/internal/server/receiver_handler_test.go
@@ -321,7 +321,7 @@ func Test_handlePayload(t *testing.T) {
 					Conditions:  []metav1.Condition{{Type: meta.StalledCondition, Status: metav1.ConditionFalse}},
 				},
 			},
-			expectedResponseCode: http.StatusNotFound,
+			expectedResponseCode: http.StatusServiceUnavailable,
 		},
 		{
 			name: "suspended receiver ignored",
@@ -337,7 +337,7 @@ func Test_handlePayload(t *testing.T) {
 					Conditions:  []metav1.Condition{{Type: meta.ReadyCondition, Status: metav1.ConditionTrue}},
 				},
 			},
-			expectedResponseCode: http.StatusNotFound,
+			expectedResponseCode: http.StatusServiceUnavailable,
 		},
 		{
 			name: "missing apiVersion in resource",
@@ -372,7 +372,7 @@ func Test_handlePayload(t *testing.T) {
 					"token": []byte("token"),
 				},
 			},
-			expectedResponseCode: http.StatusBadRequest,
+			expectedResponseCode: http.StatusInternalServerError,
 		},
 		{
 			name: "resource by name not found",
@@ -406,7 +406,7 @@ func Test_handlePayload(t *testing.T) {
 					"token": []byte("token"),
 				},
 			},
-			expectedResponseCode: http.StatusBadRequest,
+			expectedResponseCode: http.StatusInternalServerError,
 		},
 		{
 			name: "annotating resources by label match",
@@ -563,7 +563,7 @@ func Test_handlePayload(t *testing.T) {
 					"token": []byte("token"),
 				},
 			},
-			expectedResponseCode: http.StatusBadRequest,
+			expectedResponseCode: http.StatusInternalServerError,
 		},
 		{
 			name: "resource matchLabels is ignored if name is not *",
@@ -641,6 +641,7 @@ func Test_handlePayload(t *testing.T) {
 			}
 
 			builder.WithObjects(tt.resources...)
+			builder.WithIndex(&apiv1.Receiver{}, WebhookPathIndexKey, IndexReceiverWebhookPath)
 
 			if tt.secret != nil {
 				builder.WithObjects(tt.secret)


### PR DESCRIPTION
Use `.status.webhookPath` as a key to index Receivers. Use this key while listing Receivers during the handling of a payload.
This enables us to list only the Receivers required instead of listing all the Receivers in the entire cluster.