### PR TITLE
receiver/v1: Remove deprecated `.status.url` field

### DIFF
--- a/api/v1/receiver_types.go
+++ b/api/v1/receiver_types.go
@@ -85,12 +85,6 @@ type ReceiverStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	// URL is the generated incoming webhook address in the format
-	// of '/hook/sha256sum(token+name+namespace)'.
-	// Deprecated: Replaced by WebhookPath.
-	// +optional
-	URL string `json:"url,omitempty"`
-
 	// WebhookPath is the generated incoming webhook address in the format
 	// of '/hook/sha256sum(token+name+namespace)'.
 	// +optional

--- a/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
@@ -224,11 +224,6 @@ spec:
                   the Receiver object.
                 format: int64
                 type: integer
-              url:
-                description: 'URL is the generated incoming webhook address in the
-                  format of ''/hook/sha256sum(token+name+namespace)''. Deprecated:
-                  Replaced by WebhookPath.'
-                type: string
               webhookPath:
                 description: WebhookPath is the generated incoming webhook address
                   in the format of '/hook/sha256sum(token+name+namespace)'.

--- a/docs/api/v1/notification.md
+++ b/docs/api/v1/notification.md
@@ -398,20 +398,6 @@ github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
 </tr>
 <tr>
 <td>
-<code>url</code><br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>URL is the generated incoming webhook address in the format
-of &lsquo;/hook/sha256sum(token+name+namespace)&rsquo;.
-Deprecated: Replaced by WebhookPath.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>webhookPath</code><br>
 <em>
 string

--- a/internal/controllers/receiver_controller.go
+++ b/internal/controllers/receiver_controller.go
@@ -156,7 +156,6 @@ func (r *ReceiverReconciler) reconcile(ctx context.Context, obj *apiv1.Receiver)
 	token, err := r.token(ctx, obj)
 	if err != nil {
 		conditions.MarkFalse(obj, meta.ReadyCondition, apiv1.TokenNotFoundReason, err.Error())
-		obj.Status.URL = ""
 		obj.Status.WebhookPath = ""
 		return ctrl.Result{Requeue: true}, err
 	}
@@ -168,7 +167,6 @@ func (r *ReceiverReconciler) reconcile(ctx context.Context, obj *apiv1.Receiver)
 	conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, msg)
 
 	if obj.Status.WebhookPath != webhookPath {
-		obj.Status.URL = webhookPath
 		obj.Status.WebhookPath = webhookPath
 		ctrl.LoggerFrom(ctx).Info(msg)
 	}

--- a/internal/controllers/receiver_controller_test.go
+++ b/internal/controllers/receiver_controller_test.go
@@ -277,7 +277,6 @@ func TestReceiverReconciler_EventHandler(t *testing.T) {
 			return conditions.IsReady(resultR)
 		}, timeout, time.Second).Should(BeTrue())
 
-		g.Expect(resultR.Status.URL).To(BeIdenticalTo(address))
 		g.Expect(resultR.Status.WebhookPath).To(BeIdenticalTo(address))
 		g.Expect(conditions.GetMessage(resultR, meta.ReadyCondition)).To(ContainSubstring(address))
 	})
@@ -296,7 +295,6 @@ func TestReceiverReconciler_EventHandler(t *testing.T) {
 		}, timeout, time.Second).Should(BeTrue())
 
 		g.Expect(conditions.IsReady(resultR))
-		g.Expect(resultR.Status.URL).To(BeIdenticalTo(address))
 		g.Expect(resultR.Status.WebhookPath).To(BeIdenticalTo(address))
 	})
 


### PR DESCRIPTION
Receiver `.status.url` was deprecated in v1beta2 API and replaced with `.status.webhookPath`. Remove it from v1 API and all references to it.