### PR TITLE
Add config checksum from event metadata to rate limiting key

### DIFF
--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -62,7 +62,7 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		cleanupMetadata(event)
+		event.Metadata = cleanupMetadata(event)
 
 		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 		defer cancel()
@@ -325,7 +325,7 @@ func (s *EventServer) eventMatchesAlert(ctx context.Context, event *eventv1.Even
 }
 
 // cleanupMetadata removes metadata entries which are not used for alerting
-func cleanupMetadata(event *eventv1.Event) {
+func cleanupMetadata(event *eventv1.Event) map[string]string {
 	group := event.InvolvedObject.GetObjectKind().GroupVersionKind().Group
 	excludeList := []string{
 		fmt.Sprintf("%s/%s", group, eventv1.MetaChecksumKey),
@@ -343,7 +343,7 @@ func cleanupMetadata(event *eventv1.Event) {
 		}
 	}
 
-	event.Metadata = meta
+	return meta
 }
 
 func inList(l []string, i string) bool {

--- a/internal/server/event_server.go
+++ b/internal/server/event_server.go
@@ -162,5 +162,9 @@ func getEventKey(event *eventv1.Event) string {
 	if ok {
 		comps = append(comps, revString)
 	}
+	configChecksum, ok := metadata[eventv1.MetaConfigChecksumKey]
+	if ok {
+		comps = append(comps, configChecksum)
+	}
 	return strings.Join(comps, "/")
 }

--- a/internal/server/event_server.go
+++ b/internal/server/event_server.go
@@ -129,7 +129,9 @@ func (s *EventServer) logRateLimitMiddleware(h http.Handler) http.Handler {
 			s.logger.V(1).Info("Discarding event, rate limiting duplicate events",
 				"reconciler kind", event.InvolvedObject.Kind,
 				"name", event.InvolvedObject.Name,
-				"namespace", event.InvolvedObject.Namespace)
+				"namespace", event.InvolvedObject.Namespace,
+				"event metadata", event.Metadata,
+				"rate limiting key", getEventKey(event))
 		}
 	})
 }
@@ -148,12 +150,17 @@ func eventKeyFunc(r *http.Request) (string, error) {
 
 	r.Body = io.NopCloser(bytes.NewBuffer(body))
 
+	key := getEventKey(event)
+	digest := sha256.Sum256([]byte(key))
+	return fmt.Sprintf("%x", digest), nil
+}
+
+func getEventKey(event *eventv1.Event) string {
 	comps := []string{"event", event.InvolvedObject.Name, event.InvolvedObject.Namespace, event.InvolvedObject.Kind, event.Message}
-	revString, ok := event.Metadata[eventv1.MetaRevisionKey]
+	metadata := cleanupMetadata(event)
+	revString, ok := metadata[eventv1.MetaRevisionKey]
 	if ok {
 		comps = append(comps, revString)
 	}
-	val := strings.Join(comps, "/")
-	digest := sha256.Sum256([]byte(val))
-	return fmt.Sprintf("%x", digest), nil
+	return strings.Join(comps, "/")
 }


### PR DESCRIPTION
Builds on https://github.com/fluxcd/notification-controller/pull/517 and https://github.com/fluxcd/pkg/pull/544

Fixes https://github.com/fluxcd/helm-controller/issues/678 alongside https://github.com/fluxcd/helm-controller/pull/681 and https://github.com/fluxcd/pkg/pull/544