### PR TITLE
Update Alpine to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY internal/ internal/
 ENV CGO_ENABLED=0
 RUN xx-go build -trimpath -a -o notification-controller main.go
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/notification-controller"
 


### PR DESCRIPTION
This change would be nice to get in because MUSL finally implemented TCP fallback in their DNS resolver.

alpinelinux.org/posts/Alpine-3.18.0-released.html