### PR TITLE
Include eventv1.MetaTokenKey on event rate limiting key calculation

### DIFF
--- a/internal/server/event_server.go
+++ b/internal/server/event_server.go
@@ -192,9 +192,14 @@ func eventKeyFunc(r *http.Request) (string, error) {
 		event.Message,
 	}
 
-	revString, ok := event.Metadata[eventv1.MetaRevisionKey]
+	revision, ok := event.Metadata[eventv1.MetaRevisionKey]
 	if ok {
-		comps = append(comps, revString)
+		comps = append(comps, revision)
+	}
+
+	token, ok := event.Metadata[eventv1.MetaTokenKey]
+	if ok {
+		comps = append(comps, token)
 	}
 
 	val := strings.Join(comps, "/")

--- a/internal/server/event_server_test.go
+++ b/internal/server/event_server_test.go
@@ -164,6 +164,48 @@ func TestEventKeyFunc(t *testing.T) {
 			},
 			rateLimit: false,
 		},
+		{
+			involvedObject: corev1.ObjectReference{
+				APIVersion: "kustomize.toolkit.fluxcd.io/v1beta1",
+				Kind:       "Kustomization",
+				Name:       "4",
+				Namespace:  "4",
+			},
+			severity: eventv1.EventSeverityInfo,
+			message:  "Health check passed",
+			metadata: map[string]string{
+				fmt.Sprintf("%s/%s", "kustomize.toolkit.fluxcd.io", eventv1.MetaTokenKey): "token1",
+			},
+			rateLimit: false,
+		},
+		{
+			involvedObject: corev1.ObjectReference{
+				APIVersion: "kustomize.toolkit.fluxcd.io/v1beta1",
+				Kind:       "Kustomization",
+				Name:       "4",
+				Namespace:  "4",
+			},
+			severity: eventv1.EventSeverityInfo,
+			message:  "Health check passed",
+			metadata: map[string]string{
+				fmt.Sprintf("%s/%s", "kustomize.toolkit.fluxcd.io", eventv1.MetaTokenKey): "token1",
+			},
+			rateLimit: true,
+		},
+		{
+			involvedObject: corev1.ObjectReference{
+				APIVersion: "kustomize.toolkit.fluxcd.io/v1beta1",
+				Kind:       "Kustomization",
+				Name:       "4",
+				Namespace:  "4",
+			},
+			severity: eventv1.EventSeverityInfo,
+			message:  "Health check passed",
+			metadata: map[string]string{
+				fmt.Sprintf("%s/%s", "kustomize.toolkit.fluxcd.io", eventv1.MetaTokenKey): "token2",
+			},
+			rateLimit: false,
+		},
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {


### PR DESCRIPTION
Part of fixing https://github.com/fluxcd/helm-controller/issues/678

Supersedes https://github.com/fluxcd/notification-controller/pull/518