### PR TITLE
Reduce logging repeated code in event server

### DIFF
--- a/internal/server/event_handlers_test.go
+++ b/internal/server/event_handlers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -99,7 +100,7 @@ func TestEnhanceEventWithAlertMetadata(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			s.enhanceEventWithAlertMetadata(&tt.event, tt.alert)
+			s.enhanceEventWithAlertMetadata(context.Background(), &tt.event, tt.alert)
 			g.Expect(tt.event.Metadata).To(BeEquivalentTo(tt.expectedMetadata))
 		})
 	}


### PR DESCRIPTION
As discussed [here](https://github.com/fluxcd/notification-controller/pull/543#discussion_r1221308513), it would be beneficial to have a logger on the request context of the Event Server containing the event's involved object's main metadata, i.e. kind, name and namespace, so that multiple places in the code logging this information don't need to create such verbose three-liner logger every time.

I'm also seizing the opportunity to remove a lot of repeated code for logging events about Provider objects in various places of the Event Handler code.