### PR TITLE
Make Gitea tests independent of 3rd-party service

### DIFF
--- a/internal/notifier/gitea_test.go
+++ b/internal/notifier/gitea_test.go
@@ -18,35 +18,69 @@ package notifier
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
 	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
+// newTestServer returns an HTTP server mimicking parts of Gitea's API so that tests don't
+// need to rely on 3rd-party components to be available (like the try.gitea.io server).
+func newTestServer(t *testing.T) *httptest.Server {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/version":
+			fmt.Fprintf(w, `{"version":"1.18.3"}`)
+		case "/api/v1/repos/foo/bar/commits/69b59063470310ebbd88a9156325322a124e55a3/statuses":
+			fmt.Fprintf(w, "[]")
+		case "/api/v1/repos/foo/bar/statuses/69b59063470310ebbd88a9156325322a124e55a3":
+			fmt.Fprintf(w, "{}")
+		default:
+			t.Logf("unknown %s request at %s", r.Method, r.URL.Path)
+		}
+	}))
+	return srv
+}
+
 func TestNewGiteaBasic(t *testing.T) {
-	g, err := NewGitea("0c9c2e41-d2f9-4f9b-9c41-bebc1984d67a", "https://try.gitea.io/foo/bar", "foobar", nil)
-	assert.Nil(t, err)
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	g, err := NewGitea("0c9c2e41-d2f9-4f9b-9c41-bebc1984d67a", srv.URL+"/foo/bar", "foobar", nil)
+	assert.NoError(t, err)
 	assert.Equal(t, g.Owner, "foo")
 	assert.Equal(t, g.Repo, "bar")
-	assert.Equal(t, g.BaseURL, "https://try.gitea.io")
+	assert.Equal(t, g.BaseURL, srv.URL)
 }
 
 func TestNewGiteaInvalidUrl(t *testing.T) {
-	_, err := NewGitea("0c9c2e41-d2f9-4f9b-9c41-bebc1984d67a", "https://try.gitea.io/foo/bar/baz", "foobar", nil)
-	assert.NotNil(t, err)
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	_, err := NewGitea("0c9c2e41-d2f9-4f9b-9c41-bebc1984d67a", srv.URL+"/foo/bar/baz", "foobar", nil)
+	assert.ErrorContains(t, err, "invalid repository id")
 }
 
 func TestNewGiteaEmptyToken(t *testing.T) {
-	_, err := NewGitea("0c9c2e41-d2f9-4f9b-9c41-bebc1984d67a", "https://try.gitea.io/foo/bar", "", nil)
-	assert.NotNil(t, err)
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	_, err := NewGitea("0c9c2e41-d2f9-4f9b-9c41-bebc1984d67a", srv.URL+"/foo/bar", "", nil)
+	assert.ErrorContains(t, err, "gitea token cannot be empty")
 }
 
 func TestGitea_Post(t *testing.T) {
-	g, err := NewGitea("0c9c2e41-d2f9-4f9b-9c41-bebc1984d67a", "https://try.gitea.io/foo/bar", "foobar", nil)
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	g, err := NewGitea("0c9c2e41-d2f9-4f9b-9c41-bebc1984d67a", srv.URL+"/foo/bar", "foobar", nil)
 	assert.Nil(t, err)
 
 	event := eventv1.Event{
@@ -66,6 +100,5 @@ func TestGitea_Post(t *testing.T) {
 		Reason:  "",
 	}
 	err = g.Post(context.Background(), event)
-	assert.NotNil(t, err)
-	assert.ErrorContains(t, err, "404 Not Found")
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
try.gitea.io, used before this change for testing the Gitea notifier, has been provisioned with a bug that broke the tests. Now, the tests are run against a mock HTTP server mimicking parts of Gitea's API so that the tests don't rely on that 3rd-pary service, anymore.
