### PR TITLE
Lift HTTP/S validation from Provider spec.address

### DIFF
--- a/api/v1beta2/provider_types.go
+++ b/api/v1beta2/provider_types.go
@@ -74,8 +74,10 @@ type ProviderSpec struct {
 	// +optional
 	Username string `json:"username,omitempty"`
 
-	// Address specifies the HTTP/S incoming webhook address of this Provider.
-	// +kubebuilder:validation:Pattern="^(http|https)://.*$"
+	// Address specifies the endpoint, in a generic sense, to where alerts are sent.
+	// What kind of endpoint depends on the specific Provider type being used.
+	// For the generic Provider, for example, this is an HTTP/S address.
+	// For other Provider types this could be a project ID or a namespace.
 	// +kubebuilder:validation:MaxLength:=2048
 	// +kubebuilder:validation:Optional
 	// +optional

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -228,10 +228,12 @@ spec:
             description: ProviderSpec defines the desired state of the Provider.
             properties:
               address:
-                description: Address specifies the HTTP/S incoming webhook address
-                  of this Provider.
+                description: Address specifies the endpoint, in a generic sense, to
+                  where alerts are sent. What kind of endpoint depends on the specific
+                  Provider type being used. For the generic Provider, for example,
+                  this is an HTTP/S address. For other Provider types this could be
+                  a project ID or a namespace.
                 maxLength: 2048
-                pattern: ^(http|https)://.*$
                 type: string
               certSecretRef:
                 description: CertSecretRef specifies the Secret containing a PEM-encoded

--- a/docs/api/v1beta2/notification.md
+++ b/docs/api/v1beta2/notification.md
@@ -313,7 +313,10 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Address specifies the HTTP/S incoming webhook address of this Provider.</p>
+<p>Address specifies the endpoint, in a generic sense, to where alerts are sent.
+What kind of endpoint depends on the specific Provider type being used.
+For the generic Provider, for example, this is an HTTP/S address.
+For other Provider types this could be a project ID or a namespace.</p>
 </td>
 </tr>
 <tr>
@@ -902,7 +905,10 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Address specifies the HTTP/S incoming webhook address of this Provider.</p>
+<p>Address specifies the endpoint, in a generic sense, to where alerts are sent.
+What kind of endpoint depends on the specific Provider type being used.
+For the generic Provider, for example, this is an HTTP/S address.
+For other Provider types this could be a project ID or a namespace.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta2/providers.md
+++ b/docs/spec/v1beta2/providers.md
@@ -936,7 +936,10 @@ stringData:
 
 ### Address
 
-`.spec.address` is an optional field that specifies the URL where the events are posted.
+`.spec.address` is an optional field that specifies the endpoint where the events are posted.
+The meaning of endpoint here depends on the specific Provider type being used.
+For the `generic` Provider for example this is an HTTP/S address.
+For other Provider types this could be a project ID or a namespace.
 
 If the address contains sensitive information such as tokens or passwords, it is 
 recommended to store the address in the Kubernetes secret referenced by `.spec.secretRef.name`.


### PR DESCRIPTION
Addresses the discussion raised on #564 by @somtochiama.

I think this validation doesn't make sense anymore, as per this comment: https://github.com/fluxcd/notification-controller/pull/564#pullrequestreview-1501580895