### PR TITLE
Add backport GitHub Action workflow

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    labels: ["area/build"]
+    labels: ["area/ci", "dependencies"]
     schedule:
-      # by default this will be on a monday.
+      # By default, this will be on a monday.
       interval: "weekly"

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,12 @@
+# Configuration file to declaratively configure labels
+# Ref: https://github.com/EndBug/label-sync#Config-files
+
+- name: area/alerting
+  description: Alerting related issues and PRs
+  color: '#93edcf'
+- name: area/receiver
+  description: Webhook receiver related issues and PRs
+  color: '#c5def5'
+- name: backport:release/v1.0.x
+  description: To be backported to release/v1.0.x
+  color: '#ffd700'

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,32 @@
+name: backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.event.pull_request.state == 'closed' && github.event.pull_request.merged && (github.event_name != 'labeled' || startsWith('backport:', github.event.label.name))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Create backport PRs
+        uses: korthout/backport-action@bf5fdd624b35f95d5b85991a728bd5744e8c6cf2 # v1.3.1
+        # xref: https://github.com/korthout/backport-action#inputs
+        with:
+          # Match labels with a pattern `backport:<target-branch>`
+          label_pattern: '^backport:([^ ]+)$'
+          # A bit shorter pull-request title than the default
+          pull_title: '[${target_branch}] ${pull_title}'
+          # Simpler PR description than default
+          pull_description: |-
+            Automated backport to `${target_branch}`, triggered by a label in #${pull_number}.

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,0 +1,28 @@
+name: sync-labels
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  labels:
+    name: Run sync
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: EndBug/label-sync@da00f2c11fdb78e4fae44adac2fdd713778ea3e8 # v2.3.2
+        with:
+          # Configuration file
+          config-file: |
+            https://raw.githubusercontent.com/fluxcd/community/main/.github/standard-labels.yaml
+            .github/labels.yaml
+          # Strictly declarative
+          delete-other-labels: true


### PR DESCRIPTION
CI changes:
- Add backport workflow
- Add sync labels workflow

Part of: https://github.com/fluxcd/flux2/issues/4022