### PR TITLE
Delete stale metrics on object delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.1.2
 	github.com/fluxcd/pkg/git v0.12.4
 	github.com/fluxcd/pkg/masktoken v0.2.0
-	github.com/fluxcd/pkg/runtime v0.41.0
+	github.com/fluxcd/pkg/runtime v0.42.0
 	github.com/fluxcd/pkg/ssa v0.30.0
 	github.com/getsentry/sentry-go v0.23.0
 	github.com/go-logr/logr v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -774,8 +774,8 @@ github.com/fluxcd/pkg/git v0.12.4 h1:COuVYUL+gqMOYAm6oD32Vwcmy/8WVsT/nMk8ps0lpJI
 github.com/fluxcd/pkg/git v0.12.4/go.mod h1:rKB1puk7sbC4AYF1oZDBrkvu3cr0aibkd4I5yNbxSQg=
 github.com/fluxcd/pkg/masktoken v0.2.0 h1:HoSPTk4l1fz5Fevs2vVRvZGru33blfMwWSZKsHdfG/0=
 github.com/fluxcd/pkg/masktoken v0.2.0/go.mod h1:EA7GleAHL33kN6kTW06m5R3/Q26IyuGO7Ef/0CtpDI0=
-github.com/fluxcd/pkg/runtime v0.41.0 h1:hjWUwVRCKDuGEUhovWrygt/6PRry4p278yKuJNgTfv8=
-github.com/fluxcd/pkg/runtime v0.41.0/go.mod h1:1GN+nxoQ7LmSsLJwjH8JW8pA27tBSO+KLH43HpywCDM=
+github.com/fluxcd/pkg/runtime v0.42.0 h1:a5DQ/f90YjoHBmiXZUpnp4bDSLORjInbmqP7K11L4uY=
+github.com/fluxcd/pkg/runtime v0.42.0/go.mod h1:p6A3xWVV8cKLLQW0N90GehKgGMMmbNYv+OSJ/0qB0vg=
 github.com/fluxcd/pkg/ssa v0.30.0 h1:SYf8EBXevbTNwdHoKqRuU00YdnmqqUuR5xcciRrIi0E=
 github.com/fluxcd/pkg/ssa v0.30.0/go.mod h1:eUcni/amc2fM9rJ3ZR3oPeAW/ZYk3mOGO1TW9RFmAuI=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -37,6 +37,7 @@ import (
 
 	runtimeclient "github.com/fluxcd/pkg/runtime/client"
 	"github.com/fluxcd/pkg/runtime/controller"
+	"github.com/fluxcd/pkg/runtime/metrics"
 	"github.com/fluxcd/pkg/runtime/testenv"
 	"github.com/fluxcd/pkg/ssa"
 
@@ -67,7 +68,7 @@ func TestMain(m *testing.M) {
 	}
 
 	controllerName := "notification-controller"
-	testMetricsH := controller.MustMakeMetrics(testEnv)
+	testMetricsH := controller.NewMetrics(testEnv, metrics.MustMakeRecorder(), apiv1.NotificationFinalizer)
 
 	if err := (&AlertReconciler{
 		Client:         testEnv,

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ import (
 	feathelper "github.com/fluxcd/pkg/runtime/features"
 	"github.com/fluxcd/pkg/runtime/leaderelection"
 	"github.com/fluxcd/pkg/runtime/logger"
+	"github.com/fluxcd/pkg/runtime/metrics"
 	"github.com/fluxcd/pkg/runtime/pprof"
 	"github.com/fluxcd/pkg/runtime/probes"
 
@@ -158,7 +159,7 @@ func main() {
 	probes.SetupChecks(mgr, setupLog)
 	pprof.SetupHandlers(mgr, setupLog)
 
-	metricsH := helper.MustMakeMetrics(mgr)
+	metricsH := helper.NewMetrics(mgr, metrics.MustMakeRecorder(), apiv1.NotificationFinalizer)
 
 	if err = (&controller.ProviderReconciler{
 		Client:         mgr.GetClient(),


### PR DESCRIPTION
~Depends on https://github.com/fluxcd/pkg/pull/612~

The metrics helper now accepts owned finalizers to determine if an object is no longer managed by the controller and is being deleted, and deletes the metrics associated with the object.

Before this change, the following metrics continued to be exported even after the associated object is deleted for alerts, providers and receivers:
```
# HELP gotk_reconcile_condition The current condition status of a GitOps Toolkit resource reconciliation.
# TYPE gotk_reconcile_condition gauge
gotk_reconcile_condition{kind="Provider",name="slack-test",namespace="default",status="False",type="Ready"} 0
gotk_reconcile_condition{kind="Provider",name="slack-test",namespace="default",status="True",type="Ready"} 1
gotk_reconcile_condition{kind="Provider",name="slack-test",namespace="default",status="Unknown",type="Ready"} 0
# HELP gotk_reconcile_duration_seconds The duration in seconds of a GitOps Toolkit resource reconciliation.
# TYPE gotk_reconcile_duration_seconds histogram
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="0.01"} 2
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="0.038363583488692544"} 2
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="0.1471764538093883"} 2
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="0.5646216173286169"} 2
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="2.166090855590701"} 2
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="8.309900738254731"} 2
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="31.879757075478317"} 2
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="122.30217221643493"} 2
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="469.19495946736544"} 2
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="1799.9999999999986"} 2
gotk_reconcile_duration_seconds_bucket{kind="Provider",name="slack-test",namespace="default",le="+Inf"} 2
gotk_reconcile_duration_seconds_sum{kind="Provider",name="slack-test",namespace="default"} 0.014378353
gotk_reconcile_duration_seconds_count{kind="Provider",name="slack-test",namespace="default"} 2
# HELP gotk_suspend_status The current suspend status of a GitOps Toolkit resource.
# TYPE gotk_suspend_status gauge
gotk_suspend_status{kind="Provider",name="slack-test",namespace="default"} 0
```
With this change, they get deleted once the associated object is deleted.

Also, the metrics helper no longer exports `ConditionDelete` for readiness metrics.