### PR TITLE
Fix README.md links to notification APIs

### DIFF
--- a/docs/spec/v1beta1/README.md
+++ b/docs/spec/v1beta1/README.md
@@ -4,11 +4,11 @@ This is the v1alpha1 API specification for defining events handling and dispatch
 
 ## Specification
 
-* [Alert](alert.md)
-* [Event](event.md)
-* [Provider](provider.md)
-* [Receiver](receiver.md)
+* [Alert](alerts.md)
+* [Event](events.md)
+* [Provider](providers.md)
+* [Receiver](receivers.md)
 
 ## Go Client
 
-* [github.com/fluxcd/pkg/recorder](https://github.com/fluxcd/pkg/tree/main/recorder)
+* [github.com/fluxcd/pkg/runtime/events/recorder.go](https://github.com/fluxcd/pkg/blob/main/runtime/events/recorder.go#L60)


### PR DESCRIPTION
This change fixes the documentation links for the notification manager APIs.