### PR TITLE
Remove URL syntax validation for provider address entirely

### DIFF
--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -281,10 +281,6 @@ func createNotifier(ctx context.Context, kubeClient client.Client, provider apiv
 				return nil, "", fmt.Errorf("invalid address in secret: address exceeds maximum length of %d bytes", 2048)
 			}
 			webhook = string(address)
-			_, err := url.Parse(webhook)
-			if err != nil {
-				return nil, "", fmt.Errorf("invalid address in secret '%s': %w", webhook, err)
-			}
 		}
 
 		if p, ok := secret.Data["password"]; ok {

--- a/internal/server/event_handlers_test.go
+++ b/internal/server/event_handlers_test.go
@@ -571,17 +571,6 @@ func TestCreateNotifier(t *testing.T) {
 			},
 		},
 		{
-			name: "reference to secret with invalid address",
-			providerSpec: &apiv1beta3.ProviderSpec{
-				Type:      "slack",
-				SecretRef: &meta.LocalObjectReference{Name: secretName},
-			},
-			secretData: map[string][]byte{
-				"address": []byte("https://example.com|"),
-			},
-			wantErr: true,
-		},
-		{
 			name: "reference to secret with invalid proxy",
 			providerSpec: &apiv1beta3.ProviderSpec{
 				Type:      "slack",


### PR DESCRIPTION
Fixes #680 

In #564 we discussed removing the HTTP/S validation for the `.spec.address` field of a `Provider` object, and #565 was filed for implementing it. That PR missed removing the validation performed by the now deceased `ProviderReconciler`. This validation was carried over to the Event Handler, and in this PR I'm removing the validation for good.