### PR TITLE
Exclude eventv1.MetaTokenKey from event metadata

### DIFF
--- a/internal/server/event_handlers_test.go
+++ b/internal/server/event_handlers_test.go
@@ -1058,3 +1058,35 @@ func TestEnhanceEventWithAlertMetadata(t *testing.T) {
 		})
 	}
 }
+
+func Test_excludeInternalMetadata(t *testing.T) {
+	tests := []struct {
+		name         string
+		event        eventv1.Event
+		wantMetadata map[string]string
+	}{
+		{
+			name: "no metadata",
+		},
+		{
+			name: "internal metadata",
+			event: eventv1.Event{
+				Metadata: map[string]string{
+					eventv1.MetaTokenKey:    "aaaa",
+					eventv1.MetaRevisionKey: "bbbb",
+				},
+			},
+			wantMetadata: map[string]string{
+				eventv1.MetaRevisionKey: "bbbb",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			excludeInternalMetadata(&tt.event)
+			g.Expect(tt.event.Metadata).To(BeEquivalentTo(tt.wantMetadata))
+		})
+	}
+}


### PR DESCRIPTION
`eventv1.MetaTokenKey` is required to be considered in rate limiting but it is only for internal use by flux components and should not be sent to alert providers. Remove `eventv1.MetaTokenKey` from the metadata of event before processing it for matching alerts.
Fixes https://github.com/fluxcd/notification-controller/issues/650

![hc-alert-exclude-token](https://github.com/fluxcd/notification-controller/assets/614105/b0ea5009-d67f-4a89-8fc6-d52612948850)

NOTE: Initially, I added it in `cleanupMetadata()` and found out during manual testing that it removes the metadata too early which excludes it from rate limiter. Also tried adding it in `enhanceEventWithAlertMetadata()` but realized that this is too late. The same metadata will be removed for every single alert the event matches with. Removing the internal metadata right at the beginning of the event handler seems to be most appropriate.