### PR TITLE
dependabot: Ignore `go-logr` package

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,6 +16,7 @@ updates:
       # Kubernetes deps are updated by fluxcd/pkg
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
+      - dependency-name: "github.com/go-logr/*"
       # Flux APIs pkg are updated at release time
       - dependency-name: "github.com/fluxcd/notification-controller/api"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
This package updates with controller-runtime