### PR TITLE
Remove `genclient:Namespaced` tag

### DIFF
--- a/api/v1/receiver_types.go
+++ b/api/v1/receiver_types.go
@@ -122,7 +122,6 @@ func (in *Receiver) GetInterval() time.Duration {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/api/v1beta1/alert_types.go
+++ b/api/v1beta1/alert_types.go
@@ -67,7 +67,6 @@ type AlertStatus struct {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta1 Alert is deprecated, upgrade to v1beta3"

--- a/api/v1beta1/provider_types.go
+++ b/api/v1beta1/provider_types.go
@@ -110,7 +110,6 @@ type ProviderStatus struct {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta1 Provider is deprecated, upgrade to v1beta3"

--- a/api/v1beta1/receiver_types.go
+++ b/api/v1beta1/receiver_types.go
@@ -97,7 +97,6 @@ func (in *Receiver) SetConditions(conditions []metav1.Condition) {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta1 Receiver is deprecated, upgrade to v1"

--- a/api/v1beta2/alert_types.go
+++ b/api/v1beta2/alert_types.go
@@ -88,7 +88,6 @@ type AlertStatus struct {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta2 Alert is deprecated, upgrade to v1beta3"

--- a/api/v1beta2/provider_types.go
+++ b/api/v1beta2/provider_types.go
@@ -131,7 +131,6 @@ type ProviderStatus struct {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta2 Provider is deprecated, upgrade to v1beta3"

--- a/api/v1beta2/receiver_types.go
+++ b/api/v1beta2/receiver_types.go
@@ -129,7 +129,6 @@ func (in *Receiver) GetInterval() time.Duration {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion:warning="v1beta2 Receiver is deprecated, upgrade to v1"

--- a/api/v1beta3/alert_types.go
+++ b/api/v1beta3/alert_types.go
@@ -75,7 +75,6 @@ type AlertSpec struct {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""

--- a/api/v1beta3/provider_types.go
+++ b/api/v1beta3/provider_types.go
@@ -122,7 +122,6 @@ type ProviderSpec struct {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""


### PR DESCRIPTION
This tag isn't used by controller-tools, only `nonNamespaced` is.

Context: https://cloud-native.slack.com/archives/CLAJ40HV3/p1708794732147909

Tested by running `make generate` and verifying that there is no diff.