### PR TITLE
Fix Telegram MarkdownV2 escaping

### DIFF
--- a/internal/notifier/telegram.go
+++ b/internal/notifier/telegram.go
@@ -52,7 +52,7 @@ func (t *Telegram) Post(ctx context.Context, event eventv1.Event) error {
 // The telegram API requires that some special characters are escaped
 // in the message string. Docs: https://core.telegram.org/bots/api#formatting-options.
 func escapeString(str string) string {
-	chars := "\\.-_[]()~>`#+=|{}!"
+	chars := "\\.-_[]()~>`#+=|{}!*"
 	for _, char := range chars {
 		start := 0
 		idx := 0


### PR DESCRIPTION
Current implementation was missing '*' symbol.

Fixes #734

Not sure how to test message parsing, because it is implemented on the server side.