### PR TITLE
New flag to disable detailed metrics for path

### DIFF
--- a/internal/controller/receiver_controller_test.go
+++ b/internal/controller/receiver_controller_test.go
@@ -239,7 +239,7 @@ func TestReceiverReconciler_EventHandler(t *testing.T) {
 
 	// Use the client from the manager as the server handler needs to list objects from the cache
 	// which the "live" k8s client does not have access to.
-	receiverServer := server.NewReceiverServer("127.0.0.1:56788", logf.Log, testEnv.GetClient())
+	receiverServer := server.NewReceiverServer("127.0.0.1:56788", logf.Log, testEnv.GetClient(), true)
 	receiverMdlw := middleware.New(middleware.Config{
 		Recorder: prommetrics.NewRecorder(prommetrics.Config{
 			Prefix: "gotk_receiver",

--- a/internal/server/event_server_test.go
+++ b/internal/server/event_server_test.go
@@ -137,7 +137,7 @@ func TestEventServer(t *testing.T) {
 		t.Fatalf("failed to create memory storage")
 	}
 	eventServer := NewEventServer("127.0.0.1:"+eventServerPort,
-		log.Log, kclient, record.NewFakeRecorder(32), true)
+		log.Log, kclient, record.NewFakeRecorder(32), true, true)
 	stopCh := make(chan struct{})
 	go eventServer.ListenAndServe(stopCh, eventMdlw, store)
 	defer close(stopCh)

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 		aclOptions            acl.Options
 		rateLimiterOptions    helper.RateLimiterOptions
 		featureGates          feathelper.FeatureGates
-		detailedMetrics       bool
+		exportHTTPPathMetrics bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -98,7 +98,7 @@ func main() {
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
 	flag.DurationVar(&rateLimitInterval, "rate-limit-interval", 5*time.Minute, "Interval in which rate limit has effect.")
-	flag.BoolVar(&detailedMetrics, "detailed-metrics", true, "Count metrics for every requested path")
+	flag.BoolVar(&exportHTTPPathMetrics, "export-http-path-metrics", false, "When enabled, the requests full path is included in the HTTP server metrics (risk as high cardinality")
 
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
@@ -222,11 +222,11 @@ func main() {
 			Registry: crtlmetrics.Registry,
 		}),
 	})
-	eventServer := server.NewEventServer(eventsAddr, ctrl.Log, mgr.GetClient(), mgr.GetEventRecorderFor(controllerName), aclOptions.NoCrossNamespaceRefs, detailedMetrics)
+	eventServer := server.NewEventServer(eventsAddr, ctrl.Log, mgr.GetClient(), mgr.GetEventRecorderFor(controllerName), aclOptions.NoCrossNamespaceRefs, exportHTTPPathMetrics)
 	go eventServer.ListenAndServe(ctx.Done(), eventMdlw, store)
 
 	setupLog.Info("starting webhook receiver server", "addr", receiverAddr)
-	receiverServer := server.NewReceiverServer(receiverAddr, ctrl.Log, mgr.GetClient(), detailedMetrics)
+	receiverServer := server.NewReceiverServer(receiverAddr, ctrl.Log, mgr.GetClient(), exportHTTPPathMetrics)
 	receiverMdlw := middleware.New(middleware.Config{
 		Recorder: prommetrics.NewRecorder(prommetrics.Config{
 			Prefix:   "gotk_receiver",


### PR DESCRIPTION
Flag detailed-metrics added to provide a way to disable exposing all accessed paths to the metrics and  prevent potential metrics cardinality explosion

Issue ref: https://github.com/fluxcd/notification-controller/issues/828