### PR TITLE
Fix incorrect use of format strings with the `conditions` package.

### DIFF
--- a/internal/controller/receiver_controller.go
+++ b/internal/controller/receiver_controller.go
@@ -162,7 +162,7 @@ func (r *ReceiverReconciler) reconcile(ctx context.Context, obj *apiv1.Receiver)
 
 	token, err := r.token(ctx, obj)
 	if err != nil {
-		conditions.MarkFalse(obj, meta.ReadyCondition, apiv1.TokenNotFoundReason, err.Error())
+		conditions.MarkFalse(obj, meta.ReadyCondition, apiv1.TokenNotFoundReason, "%s", err)
 		obj.Status.WebhookPath = ""
 		return ctrl.Result{Requeue: true}, err
 	}
@@ -171,7 +171,7 @@ func (r *ReceiverReconciler) reconcile(ctx context.Context, obj *apiv1.Receiver)
 	msg := fmt.Sprintf("Receiver initialized for path: %s", webhookPath)
 
 	// Mark the resource as ready and set the webhook path in status.
-	conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, msg)
+	conditions.MarkTrue(obj, meta.ReadyCondition, meta.SucceededReason, "%s", msg)
 
 	if obj.Status.WebhookPath != webhookPath {
 		obj.Status.WebhookPath = webhookPath


### PR DESCRIPTION
The `Mark…` functions in the `conditions` package accept a format string and (optional) arguments, just like `fmt.Printf` and friends.

In many places, the code passed an error message as the format string, causing it to be interpreted as a format string by the `fmt` package. This leads to issues when the message contains percent signs, e.g. URL-encoded values.

This PR adds a format string and shortens `err.Error()` to `err`, which yields the same output.

This change is identical in principle to fluxcd/source-controller#1529.