### PR TITLE
Add MS Adaptive Card payload to `msteams` Provider

### DIFF
--- a/docs/spec/v1beta3/providers.md
+++ b/docs/spec/v1beta3/providers.md
@@ -350,23 +350,26 @@ stringData:
 ##### Microsoft Teams
 
 When `.spec.type` is set to `msteams`, the controller will send a payload for
-an [Event](events.md#event-structure) to the provided Microsoft Teams [Address](#address).
+an [Event](events.md#event-structure) to the provided [Address](#address). The address
+may be a [Microsoft Teams Incoming Webhook Workflow](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498), or
+the deprecated [Office 365 Connector](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/).
 
-The Event will be formatted into a Microsoft Teams
-[connector message](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#example-of-connector-message),
-with the metadata attached as facts, and the involved object as summary.
+**Note:** If the Address host contains the suffix `.webhook.office.com`, the controller will imply that
+the backend is the deprecated Office 365 Connector and is expecting the Event in the [connector message](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#example-of-connector-message) format. Otherwise, the controller will format the Event as a [Microsoft Adaptive Card](https://adaptivecards.io/explorer/) message.
+
+In both cases the Event metadata is attached as facts, and the involved object as a summary/title.
 The severity of the Event is used to set the color of the message.
 
 This Provider type supports the configuration of a [proxy URL](#https-proxy)
 and/or [TLS certificates](#tls-certificates), but lacks support for
 configuring a [Channel](#channel). This can be configured during the
-creation of the incoming webhook in Microsoft Teams.
+creation of the Incoming Webhook Workflow in Microsoft Teams.
 
 ###### Microsoft Teams example
 
 To configure a Provider for Microsoft Teams, create a Secret with [the
-`address`](#address-example) set to the [webhook URL](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook#create-incoming-webhooks-1),
-and a `msteams` Provider with a [Secret reference](#address-example).
+`address`](#address-example) set to the [webhook URL](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498),
+and an `msteams` Provider with a [Secret reference](#secret-reference).
 
 ```yaml
 ---
@@ -386,7 +389,7 @@ metadata:
   name: msteams-webhook
   namespace: default
 stringData:
-    address: "https://xxx.webhook.office.com/..."
+  address: https://prod-xxx.yyy.logic.azure.com:443/workflows/zzz/triggers/manual/paths/invoke?...
 ```
 
 ##### DataDog

--- a/internal/notifier/teams.go
+++ b/internal/notifier/teams.go
@@ -21,9 +21,20 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+)
+
+const (
+	msTeamsSchemaDeprecatedConnector = iota
+	msTeamsSchemaAdaptiveCard
+
+	// msAdaptiveCardVersion is the version of the MS Adaptive Card schema.
+	// MS Teams currently supports only up to version 1.4:
+	// https://community.powerplatform.com/forums/thread/details/?threadid=edde0a5d-e995-4ba3-96dc-2120fe51a4d0
+	msAdaptiveCardVersion = "1.4"
 )
 
 // MS Teams holds the incoming webhook URL
@@ -31,6 +42,7 @@ type MSTeams struct {
 	URL      string
 	ProxyURL string
 	CertPool *x509.CertPool
+	Schema   int
 }
 
 // MSTeamsPayload holds the message card data
@@ -54,18 +66,75 @@ type MSTeamsField struct {
 	Value string `json:"value"`
 }
 
+// The Adaptice Card payload structures below reflect this documentation:
+// https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL%2Ctext1#send-adaptive-cards-using-an-incoming-webhook
+
+type msAdaptiveCardMessage struct {
+	Type        string                     `json:"type"`
+	Attachments []msAdaptiveCardAttachment `json:"attachments"`
+}
+
+type msAdaptiveCardAttachment struct {
+	ContentType string                `json:"contentType"`
+	Content     msAdaptiveCardContent `json:"content"`
+}
+
+type msAdaptiveCardContent struct {
+	Schema  string                      `json:"$schema"`
+	Type    string                      `json:"type"`
+	Version string                      `json:"version"`
+	Body    []msAdaptiveCardBodyElement `json:"body"`
+}
+
+type msAdaptiveCardBodyElement struct {
+	Type string `json:"type"`
+
+	*msAdaptiveCardContainer `json:",inline"`
+	*msAdaptiveCardTextBlock `json:",inline"`
+	*msAdaptiveCardFactSet   `json:",inline"`
+}
+
+type msAdaptiveCardContainer struct {
+	Items []msAdaptiveCardBodyElement `json:"items,omitempty"`
+}
+
+type msAdaptiveCardTextBlock struct {
+	Text   string `json:"text,omitempty"`
+	Size   string `json:"size,omitempty"`
+	Weight string `json:"weight,omitempty"`
+	Color  string `json:"color,omitempty"`
+	Wrap   bool   `json:"wrap,omitempty"`
+}
+
+type msAdaptiveCardFactSet struct {
+	Facts []msAdaptiveCardFact `json:"facts,omitempty"`
+}
+
+type msAdaptiveCardFact struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+}
+
 // NewMSTeams validates the MS Teams URL and returns a MSTeams object
 func NewMSTeams(hookURL string, proxyURL string, certPool *x509.CertPool) (*MSTeams, error) {
-	_, err := url.ParseRequestURI(hookURL)
+	u, err := url.ParseRequestURI(hookURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid MS Teams webhook URL %s: '%w'", hookURL, err)
 	}
 
-	return &MSTeams{
+	provider := &MSTeams{
 		URL:      hookURL,
 		ProxyURL: proxyURL,
 		CertPool: certPool,
-	}, nil
+		Schema:   msTeamsSchemaAdaptiveCard,
+	}
+
+	// Check if the webhook URL is the deprecated connector and update the schema accordingly.
+	if strings.HasSuffix(strings.Split(u.Host, ":")[0], ".webhook.office.com") {
+		provider.Schema = msTeamsSchemaDeprecatedConnector
+	}
+
+	return provider, nil
 }
 
 // Post MS Teams message
@@ -75,6 +144,27 @@ func (s *MSTeams) Post(ctx context.Context, event eventv1.Event) error {
 		return nil
 	}
 
+	objName := fmt.Sprintf("%s/%s.%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.InvolvedObject.Namespace)
+
+	var payload any
+	switch s.Schema {
+	case msTeamsSchemaDeprecatedConnector:
+		payload = buildMSTeamsDeprecatedConnectorPayload(&event, objName)
+	case msTeamsSchemaAdaptiveCard:
+		payload = buildMSTeamsAdaptiveCardPayload(&event, objName)
+	default:
+		payload = buildMSTeamsAdaptiveCardPayload(&event, objName)
+	}
+
+	err := postMessage(ctx, s.URL, s.ProxyURL, s.CertPool, payload)
+	if err != nil {
+		return fmt.Errorf("postMessage failed: %w", err)
+	}
+
+	return nil
+}
+
+func buildMSTeamsDeprecatedConnectorPayload(event *eventv1.Event, objName string) *MSTeamsPayload {
 	facts := make([]MSTeamsField, 0, len(event.Metadata))
 	for k, v := range event.Metadata {
 		facts = append(facts, MSTeamsField{
@@ -83,8 +173,7 @@ func (s *MSTeams) Post(ctx context.Context, event eventv1.Event) error {
 		})
 	}
 
-	objName := fmt.Sprintf("%s/%s.%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.InvolvedObject.Namespace)
-	payload := MSTeamsPayload{
+	payload := &MSTeamsPayload{
 		Type:       "MessageCard",
 		Context:    "http://schema.org/extensions",
 		ThemeColor: "0076D7",
@@ -102,10 +191,84 @@ func (s *MSTeams) Post(ctx context.Context, event eventv1.Event) error {
 		payload.ThemeColor = "FF0000"
 	}
 
-	err := postMessage(ctx, s.URL, s.ProxyURL, s.CertPool, payload)
-	if err != nil {
-		return fmt.Errorf("postMessage failed: %w", err)
+	return payload
+}
+
+func buildMSTeamsAdaptiveCardPayload(event *eventv1.Event, objName string) *msAdaptiveCardMessage {
+	// Prepare message, add red color to error messages.
+	message := &msAdaptiveCardTextBlock{
+		Text: event.Message,
+		Wrap: true,
+	}
+	if event.Severity == eventv1.EventSeverityError {
+		message.Color = "attention"
 	}
 
-	return nil
+	// Put "summary" first, then sort the rest of the metadata by key.
+	facts := make([]msAdaptiveCardFact, 0, len(event.Metadata))
+	const summaryKey = "summary"
+	if summary, ok := event.Metadata[summaryKey]; ok {
+		facts = append(facts, msAdaptiveCardFact{
+			Title: summaryKey,
+			Value: summary,
+		})
+	}
+	metadataFirstIndex := len(facts)
+	for k, v := range event.Metadata {
+		if k == summaryKey {
+			continue
+		}
+		facts = append(facts, msAdaptiveCardFact{
+			Title: k,
+			Value: v,
+		})
+	}
+	slices.SortFunc(facts[metadataFirstIndex:], func(a, b msAdaptiveCardFact) int {
+		return strings.Compare(a.Title, b.Title)
+	})
+
+	// The card below was built with help from https://adaptivecards.io/designer using the Microsoft Teams host app.
+	payload := &msAdaptiveCardMessage{
+		Type: "message",
+		Attachments: []msAdaptiveCardAttachment{
+			{
+				ContentType: "application/vnd.microsoft.card.adaptive",
+				Content: msAdaptiveCardContent{
+					Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+					Type:    "AdaptiveCard",
+					Version: msAdaptiveCardVersion,
+					Body: []msAdaptiveCardBodyElement{
+						{
+							Type: "Container",
+							msAdaptiveCardContainer: &msAdaptiveCardContainer{
+								Items: []msAdaptiveCardBodyElement{
+									{
+										Type: "TextBlock",
+										msAdaptiveCardTextBlock: &msAdaptiveCardTextBlock{
+											Text:   objName,
+											Size:   "large",
+											Weight: "bolder",
+											Wrap:   true,
+										},
+									},
+									{
+										Type:                    "TextBlock",
+										msAdaptiveCardTextBlock: message,
+									},
+									{
+										Type: "FactSet",
+										msAdaptiveCardFactSet: &msAdaptiveCardFactSet{
+											Facts: facts,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return payload
 }

--- a/internal/notifier/teams_test.go
+++ b/internal/notifier/teams_test.go
@@ -24,11 +24,52 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestTeams_Post(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestNewMSTeams(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantSchema int
+	}{
+		{
+			name:       "deprecated connector url",
+			url:        "https://xxx.webhook.office.com",
+			wantSchema: msTeamsSchemaDeprecatedConnector,
+		},
+		{
+			name:       "deprecated connector url with port",
+			url:        "https://xxx.webhook.office.com:443",
+			wantSchema: msTeamsSchemaDeprecatedConnector,
+		},
+		{
+			name:       "url close to deprecated connector url but different",
+			url:        "https://xxx-webhook.office.com",
+			wantSchema: msTeamsSchemaAdaptiveCard,
+		},
+		{
+			name:       "incoming webhook workflow url",
+			url:        "https://prod-28.northeurope.logic.azure.com:443/workflows/xxx/triggers/manual/paths/invoke",
+			wantSchema: msTeamsSchemaAdaptiveCard,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			teams, err := NewMSTeams(tt.url, "", nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSchema, teams.Schema)
+		})
+	}
+}
+
+func TestMSTeams_Post(t *testing.T) {
+	var deprecatedConnectorCalled bool
+	deprecatedConnectorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deprecatedConnectorCalled = true
+
 		b, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		var payload = MSTeamsPayload{}
@@ -38,11 +79,94 @@ func TestTeams_Post(t *testing.T) {
 		require.Equal(t, "gitrepository/webapp.gitops-system", payload.Sections[0].ActivitySubtitle)
 		require.Equal(t, "metadata", payload.Sections[0].Facts[0].Value)
 	}))
-	defer ts.Close()
+	defer deprecatedConnectorServer.Close()
 
-	teams, err := NewMSTeams(ts.URL, "", nil)
-	require.NoError(t, err)
+	var adaptiveCardCalled bool
+	adaptiveCardServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		adaptiveCardCalled = true
 
-	err = teams.Post(context.TODO(), testEvent())
-	require.NoError(t, err)
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var payload map[string]any
+		err = json.Unmarshal(b, &payload)
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]any{
+			"type": "message",
+			"attachments": []any{
+				map[string]any{
+					"contentType": "application/vnd.microsoft.card.adaptive",
+					"content": map[string]any{
+						"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+						"type":    "AdaptiveCard",
+						"version": "1.4",
+						"body": []any{
+							map[string]any{
+								"type": "Container",
+								"items": []any{
+									map[string]any{
+										"type":   "TextBlock",
+										"size":   "large",
+										"text":   "gitrepository/webapp.gitops-system",
+										"weight": "bolder",
+										"wrap":   true,
+									},
+									map[string]any{
+										"type": "TextBlock",
+										"text": "message",
+										"wrap": true,
+									},
+									map[string]any{
+										"type": "FactSet",
+										"facts": []any{
+											map[string]any{
+												"title": "test",
+												"value": "metadata",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, payload)
+	}))
+	defer adaptiveCardServer.Close()
+
+	tests := []struct {
+		name         string
+		url          string
+		schema       int
+		serverCalled *bool
+	}{
+		{
+			name:         "deprecated connector",
+			url:          deprecatedConnectorServer.URL,
+			schema:       msTeamsSchemaDeprecatedConnector,
+			serverCalled: &deprecatedConnectorCalled,
+		},
+		{
+			name:         "adaptive card",
+			url:          adaptiveCardServer.URL,
+			schema:       msTeamsSchemaAdaptiveCard,
+			serverCalled: &adaptiveCardCalled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			*tt.serverCalled = false
+
+			teams, err := NewMSTeams(tt.url, "", nil)
+			require.NoError(t, err)
+			teams.Schema = tt.schema
+
+			err = teams.Post(context.TODO(), testEvent())
+			require.NoError(t, err)
+
+			assert.True(t, *tt.serverCalled)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #878 

The solution implemented in this PR for addressing the deprecation of the Office 365 Connector is checking the host of the address. If the suffix `.webhook.office.com` is present, the controller will keep the old behavior and send the existing payload format. Otherwise, a new payload format for Microsoft Adaptive Card will be sent, which is compatible with the new solution offered by Microsoft Teams: [Incoming Webhook with Workflows](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498).