### PR TITLE
fix: adding of duplicate commit statuses in gitlab

### DIFF
--- a/internal/notifier/gitlab.go
+++ b/internal/notifier/gitlab.go
@@ -99,7 +99,9 @@ func (g *GitLab) Post(ctx context.Context, event eventv1.Event) error {
 		Description: desc,
 	}
 
-	getOpt := &gitlab.GetCommitStatusesOptions{}
+	getOpt := &gitlab.GetCommitStatusesOptions{
+		Name: &status.Name,
+	}
 	statuses, _, err := g.Client.Commits.GetCommitStatuses(g.Id, rev, getOpt, gitlab.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("unable to list commit status: %s", err)


### PR DESCRIPTION
The get commit-status request is paginated and only returns the first 20 commit statuses by default. This change fetches the commit-status by name to avoid multiple requests.

RESOLVES #1009