### PR TITLE
msteams notifier: adaptive cards full width

### DIFF
--- a/internal/notifier/teams.go
+++ b/internal/notifier/teams.go
@@ -84,6 +84,7 @@ type msAdaptiveCardContent struct {
 	Type    string                      `json:"type"`
 	Version string                      `json:"version"`
 	Body    []msAdaptiveCardBodyElement `json:"body"`
+	MSTeams msAdaptiveCardMSTeams       `json:"msteams"`
 }
 
 type msAdaptiveCardBodyElement struct {
@@ -96,6 +97,10 @@ type msAdaptiveCardBodyElement struct {
 
 type msAdaptiveCardContainer struct {
 	Items []msAdaptiveCardBodyElement `json:"items,omitempty"`
+}
+
+type msAdaptiveCardMSTeams struct {
+	Width string `json:"width,omitempty"`
 }
 
 type msAdaptiveCardTextBlock struct {
@@ -237,6 +242,9 @@ func buildMSTeamsAdaptiveCardPayload(event *eventv1.Event, objName string) *msAd
 					Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
 					Type:    "AdaptiveCard",
 					Version: msAdaptiveCardVersion,
+					MSTeams: msAdaptiveCardMSTeams{
+						Width: "Full",
+					},
 					Body: []msAdaptiveCardBodyElement{
 						{
 							Type: "Container",

--- a/internal/notifier/teams_test.go
+++ b/internal/notifier/teams_test.go
@@ -100,6 +100,9 @@ func TestMSTeams_Post(t *testing.T) {
 						"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
 						"type":    "AdaptiveCard",
 						"version": "1.4",
+						"msteams": map[string]any{
+							"width": "Full",
+						},
 						"body": []any{
 							map[string]any{
 								"type": "Container",


### PR DESCRIPTION
In teams notifications, configure the adaptive card to expand and make full use of extra canvas space by setting the `msteams.width` property to `Full` (https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-format?tabs=adaptive-md%2Cdesktop%2Cdesktop1%2Cdesktop2%2Cconnector-html#full-width-adaptive-card).

This allow the card to be wider and more similar to the legacy message card version.

This is an implementation of the point 1 in https://github.com/fluxcd/notification-controller/issues/956.

Before:
![image](https://github.com/user-attachments/assets/c4a40d05-78d9-44a8-a334-b29cd1e7b6d8)

After:
![image](https://github.com/user-attachments/assets/b3b21193-711c-4af5-b093-a8f11395923e)

