### PR TITLE
Add support for Bearer Token authentication to Provider `alertmanager`

### DIFF
--- a/docs/spec/v1beta3/providers.md
+++ b/docs/spec/v1beta3/providers.md
@@ -919,10 +919,13 @@ and [TLS certificates](#tls-certificates).
 
 ###### Prometheus Alertmanager example
 
-To configure a Provider for Prometheus Alertmanager, create a Secret with [the
-`address`](#address-example) set to the Prometheus Alertmanager [HTTP API
+To configure a Provider for Prometheus Alertmanager, authentication can be done using either Basic Authentication or a Bearer Token. 
+Both methods are supported, but using authentication is optional based on your setup.
+
+Basic Authentication: 
+Create a Secret with [the `address`](#address-example) set to the Prometheus Alertmanager [HTTP API
 URL](https://prometheus.io/docs/alerting/latest/https/#http-traffic)
-including Basic Auth credentials, and a `alertmanager` Provider with a [Secret
+including Basic Auth credentials, and an `alertmanager` Provider with a [Secret
 reference](#secret-reference).
 
 ```yaml
@@ -943,7 +946,33 @@ metadata:
   name: alertmanager-address
   namespace: default
 stringData:
-    address: https://username:password@<alertmanager-url>/api/v2/alerts/"
+    address: https://<username>:<password>@<alertmanager-hostport>/api/v2/alerts/
+```
+Bearer Token Authentication:
+Create a Secret with [the `token`](#token-example), and an `alertmanager` Provider with a [Secret
+reference](#secret-reference) and the Prometheus Alertmanager [HTTP API
+URL](https://prometheus.io/docs/alerting/latest/https/#http-traffic) set directly in the `.spec.address` field.
+
+```yaml
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: alertmanager
+  namespace: default
+spec:
+  type: alertmanager
+  address: https://<alertmanager-hostport>/api/v2/alerts/
+  secretRef:
+    name: alertmanager-token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-token
+  namespace: default
+stringData:
+    token: <token>
 ```
 
 ##### Webex

--- a/internal/notifier/alertmanager_fuzz_test.go
+++ b/internal/notifier/alertmanager_fuzz_test.go
@@ -46,7 +46,7 @@ func Fuzz_AlertManager(f *testing.F) {
 		var cert x509.CertPool
 		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
 
-		alertmanager, err := NewAlertmanager(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", &cert)
+		alertmanager, err := NewAlertmanager(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", &cert, "")
 		if err != nil {
 			return
 		}

--- a/internal/notifier/alertmanager_test.go
+++ b/internal/notifier/alertmanager_test.go
@@ -38,7 +38,7 @@ func TestAlertmanager_Post(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	alertmanager, err := NewAlertmanager(ts.URL, "", nil)
+	alertmanager, err := NewAlertmanager(ts.URL, "", nil, "")
 	require.NoError(t, err)
 
 	err = alertmanager.Post(context.TODO(), testEvent())

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -185,7 +185,7 @@ func opsgenieNotifierFunc(opts notifierOptions) (Interface, error) {
 }
 
 func alertmanagerNotifierFunc(opts notifierOptions) (Interface, error) {
-	return NewAlertmanager(opts.URL, opts.ProxyURL, opts.CertPool)
+	return NewAlertmanager(opts.URL, opts.ProxyURL, opts.CertPool, opts.Token)
 }
 
 func grafanaNotifierFunc(opts notifierOptions) (Interface, error) {


### PR DESCRIPTION
I'm not a programmer, but after examining the other providers, i think this should be correct. Please let me know :)

Closes: #1020 