### PR TITLE
Update docs to include Telegram forum configuration

### DIFF
--- a/docs/spec/v1beta1/providers.md
+++ b/docs/spec/v1beta1/providers.md
@@ -368,7 +368,8 @@ and use `https://api.telegram.org/` as the api url.
  --from-literal=address=https://api.telegram.org
 ```
 
-Also note that `spec.channel` can be a unique identifier for the target chat
+Also note that `spec.channel` can be a unique identifier for the target chat,
+a unique identifier with the topic identifier for the forum chat
 or username of the target channel (in the format @channelusername)
 
 ```yaml
@@ -379,7 +380,7 @@ metadata:
   namespace: flux-system
 spec:
   type: telegram
-  channel: "@fluxtest" # or "-1557265138" (channel id)
+  channel: "@fluxtest" # or "-1557265138" (channel id) or "-1552289257:1" (forum chat id with topic id)
   secretRef:
     name: telegram-token
 ```

--- a/docs/spec/v1beta2/providers.md
+++ b/docs/spec/v1beta2/providers.md
@@ -563,8 +563,9 @@ The Event will be formatted into a message string, with the metadata attached
 as a list of key-value pairs.
 
 The Provider's [Channel](#channel) is used to set the receiver of the message.
-This can be a unique identifier (`-1234567890`) for the target chat, or
-the username (`@username`) of the target channel.
+This can be a unique identifier (`-1234567890`) for the target chat,
+a unique identifier with the topic identifier (`-1234567890:1`) for the forum chat,
+or the username (`@username`) of the target channel.
 
 This Provider type does not support the configuration of a [proxy URL](#https-proxy)
 or [TLS certificates](#tls-certificates).
@@ -586,7 +587,7 @@ metadata:
 spec:
   type: telegram
   address: https://api.telegram.org
-  channel: "@fluxcd" # or "-1557265138" (channel id)
+  channel: "@fluxcd" # or "-1557265138" (channel id) or "-1552289257:1" (forum chat id with topic id)
   secretRef:
     name: telegram-token
 ```

--- a/docs/spec/v1beta3/providers.md
+++ b/docs/spec/v1beta3/providers.md
@@ -550,8 +550,9 @@ The Event will be formatted into a message string, with the metadata attached
 as a list of key-value pairs.
 
 The Provider's [Channel](#channel) is used to set the receiver of the message.
-This can be a unique identifier (`-1234567890`) for the target chat, or
-the username (`@username`) of the target channel.
+This can be a unique identifier (`-1234567890`) for the target chat,
+a unique identifier with the topic identifier (`-1234567890:1`) for the forum chat,
+or the username (`@username`) of the target channel.
 
 This Provider type does not support the configuration of a [proxy URL](#https-proxy)
 or [TLS certificates](#tls-certificates).
@@ -573,7 +574,7 @@ metadata:
 spec:
   type: telegram
   address: https://api.telegram.org
-  channel: "@fluxcd" # or "-1557265138" (channel id)
+  channel: "@fluxcd" # or "-1557265138" (channel id) or "-1552289257:1" (forum chat id with topic id)
   secretRef:
     name: telegram-token
 ```


### PR DESCRIPTION
Current documentation does not mention that Telegram provider supports Telegram forum chats' topics, which it does, since [the shoutrrr lib does](https://github.com/containrrr/shoutrrr/pull/362/files). Therefore, no changes are needed in the FluxCD Notification Controller in order to send Telegram alerts to said topics.

This PR contains documentation changes that describe how you can set Telegram provider up to work with Telegram forum chats.

Closes [#1063](https://github.com/fluxcd/notification-controller/issues/1063) 