### PR TITLE
fix: pass 'certPool' to Gitea client on creation

### DIFF
--- a/internal/notifier/gitea.go
+++ b/internal/notifier/gitea.go
@@ -69,18 +69,16 @@ func NewGitea(commitStatus string, addr string, token string, certPool *x509.Cer
 		return nil, fmt.Errorf("invalid repository id %q", id)
 	}
 
-	client, err := gitea.NewClient(host, gitea.SetToken(token))
-	if err != nil {
-		return nil, fmt.Errorf("failed creating Gitea client: %w", err)
+	tr := &http.Transport{}
+	if certPool != nil {
+		tr.TLSClientConfig = &tls.Config{
+			RootCAs: certPool,
+		}
 	}
 
-	if certPool != nil {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: certPool,
-			},
-		}
-		client.SetHTTPClient(&http.Client{Transport: tr})
+	client, err := gitea.NewClient(host, gitea.SetToken(token), gitea.SetHTTPClient(&http.Client{Transport: tr}))
+	if err != nil {
+		return nil, fmt.Errorf("failed creating Gitea client: %w", err)
 	}
 
 	return &Gitea{


### PR DESCRIPTION
It is required when a custom CA is passed, otherwise the gitea.NewClient() call will fail with the 'tls: failed to verify certificate: x509: certificate signed by unknown authority' error. Because the current version of Gitea SDK performs a call to the '/api/v1/version' endpoint during a new client creation, so the 'certPool' must be passed when creating the client.

Resolves: #1083