### PR TITLE
Fix Slack `chat.postMessage` error handling

### DIFF
--- a/internal/notifier/alertmanager.go
+++ b/internal/notifier/alertmanager.go
@@ -137,13 +137,17 @@ func (s *Alertmanager) Post(ctx context.Context, event eventv1.Event) error {
 		},
 	}
 
-	var opts []requestOptFunc
-	if s.Token != "" {
-		opts = append(opts, func(request *retryablehttp.Request) {
-			request.Header.Add("Authorization", "Bearer "+s.Token)
-		})
+	opts := []messageOption{
+		withProxy(s.ProxyURL),
+		withCertPool(s.CertPool),
 	}
-	err := postMessage(ctx, s.URL, s.ProxyURL, s.CertPool, payload, opts...)
+	if s.Token != "" {
+		opts = append(opts,
+			withRequestOption(func(request *retryablehttp.Request) {
+				request.Header.Add("Authorization", "Bearer "+s.Token)
+			}))
+	}
+	err := postMessage(ctx, s.URL, payload, opts...)
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}

--- a/internal/notifier/client.go
+++ b/internal/notifier/client.go
@@ -33,16 +33,25 @@ import (
 )
 
 type messageOptions struct {
-	proxy    string
-	certPool *x509.CertPool
-	reqOpts  []requestOptFunc
+	proxy            string
+	certPool         *x509.CertPool
+	reqOpts          []requestOptFunc
+	validateResponse func(*http.Response) bool
 }
 type requestOptFunc func(*retryablehttp.Request)
 
 type messageOption func(*messageOptions)
 
 func postMessage(ctx context.Context, address string, payload interface{}, options ...messageOption) error {
-	opts := &messageOptions{}
+	opts := &messageOptions{
+		// Default validateResponse function varifies that the response status code is 200, 202 or 201.
+		validateResponse: func(resp *http.Response) bool {
+			return resp.StatusCode == http.StatusOK ||
+				resp.StatusCode == http.StatusAccepted ||
+				resp.StatusCode == http.StatusCreated
+		},
+	}
+
 	for _, o := range options {
 		o(opts)
 	}
@@ -61,6 +70,7 @@ func postMessage(ctx context.Context, address string, payload interface{}, optio
 	if err != nil {
 		return fmt.Errorf("failed to create a new request: %w", err)
 	}
+
 	if ctx != nil {
 		req = req.WithContext(ctx)
 	}
@@ -68,12 +78,14 @@ func postMessage(ctx context.Context, address string, payload interface{}, optio
 	for _, o := range opts.reqOpts {
 		o(req)
 	}
+
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
+	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusCreated {
+	if !opts.validateResponse(resp) {
 		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("unable to read response body, %s", err)
@@ -99,6 +111,12 @@ func withCertPool(certPool *x509.CertPool) messageOption {
 func withRequestOption(reqOpt requestOptFunc) messageOption {
 	return func(opts *messageOptions) {
 		opts.reqOpts = append(opts.reqOpts, reqOpt)
+	}
+}
+
+func withValidateResponse(validateResponse func(*http.Response) bool) messageOption {
+	return func(opts *messageOptions) {
+		opts.validateResponse = validateResponse
 	}
 }
 

--- a/internal/notifier/client.go
+++ b/internal/notifier/client.go
@@ -32,29 +32,99 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
+type messageOptions struct {
+	proxy    string
+	certPool *x509.CertPool
+	reqOpts  []requestOptFunc
+}
 type requestOptFunc func(*retryablehttp.Request)
 
-func postMessage(ctx context.Context, address, proxy string, certPool *x509.CertPool, payload interface{}, reqOpts ...requestOptFunc) error {
+type messageOption func(*messageOptions)
+
+func postMessage(ctx context.Context, address string, payload interface{}, options ...messageOption) error {
+	opts := &messageOptions{}
+	for _, o := range options {
+		o(opts)
+	}
+
+	httpClient, err := newHTTPClient(opts)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshalling notification payload failed: %w", err)
+	}
+
+	req, err := retryablehttp.NewRequest(http.MethodPost, address, data)
+	if err != nil {
+		return fmt.Errorf("failed to create a new request: %w", err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for _, o := range opts.reqOpts {
+		o(req)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusCreated {
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("unable to read response body, %s", err)
+		}
+		return fmt.Errorf("request failed with status code %d, %s", resp.StatusCode, string(b))
+	}
+
+	return nil
+}
+
+func withProxy(proxy string) messageOption {
+	return func(opts *messageOptions) {
+		opts.proxy = proxy
+	}
+}
+
+func withCertPool(certPool *x509.CertPool) messageOption {
+	return func(opts *messageOptions) {
+		opts.certPool = certPool
+	}
+}
+
+func withRequestOption(reqOpt requestOptFunc) messageOption {
+	return func(opts *messageOptions) {
+		opts.reqOpts = append(opts.reqOpts, reqOpt)
+	}
+}
+
+func newHTTPClient(opts *messageOptions) (*retryablehttp.Client, error) {
 	httpClient := retryablehttp.NewClient()
-	if certPool != nil {
+	if opts.certPool != nil {
 		httpClient.HTTPClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs: certPool,
+				RootCAs: opts.certPool,
 			},
 		}
 	}
 
-	if proxy != "" {
-		proxyURL, err := url.Parse(proxy)
+	if opts.proxy != "" {
+		proxyURL, err := url.Parse(opts.proxy)
 		if err != nil {
-			return fmt.Errorf("unable to parse proxy URL '%s', error: %w", proxy, err)
+			return nil, fmt.Errorf("unable to parse proxy URL '%s', error: %w", opts.proxy, err)
 		}
+
 		var tlsConfig *tls.Config
-		if certPool != nil {
+		if opts.certPool != nil {
 			tlsConfig = &tls.Config{
-				RootCAs: certPool,
+				RootCAs: opts.certPool,
 			}
 		}
+
 		httpClient.HTTPClient.Transport = &http.Transport{
 			Proxy:           http.ProxyURL(proxyURL),
 			TLSClientConfig: tlsConfig,
@@ -79,34 +149,5 @@ func postMessage(ctx context.Context, address, proxy string, certPool *x509.Cert
 	httpClient.RetryMax = 4
 	httpClient.Logger = nil
 
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("marshalling notification payload failed: %w", err)
-	}
-
-	req, err := retryablehttp.NewRequest(http.MethodPost, address, data)
-	if err != nil {
-		return fmt.Errorf("failed to create a new request: %w", err)
-	}
-	if ctx != nil {
-		req = req.WithContext(ctx)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	for _, o := range reqOpts {
-		o(req)
-	}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusCreated {
-		b, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("unable to read response body, %s", err)
-		}
-		return fmt.Errorf("request failed with status code %d, %s", resp.StatusCode, string(b))
-	}
-
-	return nil
+	return httpClient, nil
 }

--- a/internal/notifier/client_test.go
+++ b/internal/notifier/client_test.go
@@ -45,7 +45,7 @@ func Test_postMessage(t *testing.T) {
 		require.Equal(t, "success", payload["status"])
 	}))
 	defer ts.Close()
-	err := postMessage(context.Background(), ts.URL, "", nil, map[string]string{"status": "success"})
+	err := postMessage(context.Background(), ts.URL, map[string]string{"status": "success"})
 	require.NoError(t, err)
 }
 
@@ -56,7 +56,7 @@ func Test_postMessage_timeout(t *testing.T) {
 	defer ts.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	err := postMessage(ctx, ts.URL, "", nil, map[string]string{"status": "success"})
+	err := postMessage(ctx, ts.URL, map[string]string{"status": "success"})
 	require.Error(t, err, "context deadline exceeded")
 }
 
@@ -77,7 +77,7 @@ func Test_postSelfSignedCert(t *testing.T) {
 	require.NoError(t, err)
 	certpool := x509.NewCertPool()
 	certpool.AddCert(cert)
-	err = postMessage(context.Background(), ts.URL, "", certpool, map[string]string{"status": "success"})
+	err = postMessage(context.Background(), ts.URL, map[string]string{"status": "success"}, withCertPool(certpool))
 	require.NoError(t, err)
 }
 

--- a/internal/notifier/discord.go
+++ b/internal/notifier/discord.go
@@ -90,7 +90,7 @@ func (s *Discord) Post(ctx context.Context, event eventv1.Event) error {
 
 	payload.Attachments = []SlackAttachment{a}
 
-	err := postMessage(ctx, s.URL, s.ProxyURL, nil, payload)
+	err := postMessage(ctx, s.URL, payload, withProxy(s.ProxyURL))
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}

--- a/internal/notifier/forwarder.go
+++ b/internal/notifier/forwarder.go
@@ -77,15 +77,17 @@ func (f *Forwarder) Post(ctx context.Context, event eventv1.Event) error {
 		}
 		sig = fmt.Sprintf("sha256=%s", sign(eventJSON, f.HMACKey))
 	}
-	err := postMessage(ctx, f.URL, f.ProxyURL, f.CertPool, event, func(req *retryablehttp.Request) {
-		req.Header.Set(NotificationHeader, event.ReportingController)
-		for key, val := range f.Headers {
-			req.Header.Set(key, val)
-		}
-		if sig != "" {
-			req.Header.Set("X-Signature", sig)
-		}
-	})
+	err := postMessage(
+		ctx, f.URL, event, withProxy(f.ProxyURL), withCertPool(f.CertPool),
+		withRequestOption(func(req *retryablehttp.Request) {
+			req.Header.Set(NotificationHeader, event.ReportingController)
+			for key, val := range f.Headers {
+				req.Header.Set(key, val)
+			}
+			if sig != "" {
+				req.Header.Set("X-Signature", sig)
+			}
+		}))
 
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)

--- a/internal/notifier/google_chat.go
+++ b/internal/notifier/google_chat.go
@@ -142,7 +142,7 @@ func (s *GoogleChat) Post(ctx context.Context, event eventv1.Event) error {
 		Cards: []GoogleChatCard{card},
 	}
 
-	err := postMessage(ctx, s.URL, s.ProxyURL, nil, payload)
+	err := postMessage(ctx, s.URL, payload, withProxy(s.ProxyURL))
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}

--- a/internal/notifier/grafana.go
+++ b/internal/notifier/grafana.go
@@ -84,14 +84,17 @@ func (g *Grafana) Post(ctx context.Context, event eventv1.Event) error {
 		Tags: sfields,
 	}
 
-	err := postMessage(ctx, g.URL, g.ProxyURL, g.CertPool, payload, func(request *retryablehttp.Request) {
-		if (g.Username != "" && g.Password != "") && g.Token == "" {
-			request.Header.Add("Authorization", "Basic "+basicAuth(g.Username, g.Password))
-		}
-		if g.Token != "" {
-			request.Header.Add("Authorization", "Bearer "+g.Token)
-		}
-	})
+	err := postMessage(
+		ctx, g.URL, payload, withProxy(g.ProxyURL), withCertPool(g.CertPool),
+		withRequestOption(func(req *retryablehttp.Request) {
+			if (g.Username != "" && g.Password != "") && g.Token == "" {
+				req.Header.Add("Authorization", "Basic "+basicAuth(g.Username, g.Password))
+			}
+			if g.Token != "" {
+				req.Header.Add("Authorization", "Bearer "+g.Token)
+			}
+		}),
+	)
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}

--- a/internal/notifier/lark.go
+++ b/internal/notifier/lark.go
@@ -109,5 +109,5 @@ func (l *Lark) Post(ctx context.Context, event eventv1.Event) error {
 		Card:    card,
 	}
 
-	return postMessage(ctx, l.URL, "", nil, payload)
+	return postMessage(ctx, l.URL, payload)
 }

--- a/internal/notifier/matrix.go
+++ b/internal/notifier/matrix.go
@@ -65,10 +65,13 @@ func (m *Matrix) Post(ctx context.Context, event eventv1.Event) error {
 		MsgType: "m.text",
 	}
 
-	err = postMessage(ctx, fullURL, "", m.CertPool, payload, func(request *retryablehttp.Request) {
-		request.Method = http.MethodPut
-		request.Header.Add("Authorization", "Bearer "+m.Token)
-	})
+	err = postMessage(
+		ctx, fullURL, payload, withCertPool(m.CertPool),
+		withRequestOption(func(request *retryablehttp.Request) {
+			request.Method = http.MethodPut
+			request.Header.Add("Authorization", "Bearer "+m.Token)
+		}),
+	)
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}

--- a/internal/notifier/opsgenie.go
+++ b/internal/notifier/opsgenie.go
@@ -78,9 +78,12 @@ func (s *Opsgenie) Post(ctx context.Context, event eventv1.Event) error {
 		Details:     details,
 	}
 
-	err := postMessage(ctx, s.URL, s.ProxyURL, s.CertPool, payload, func(req *retryablehttp.Request) {
-		req.Header.Set("Authorization", "GenieKey "+s.ApiKey)
-	})
+	err := postMessage(
+		ctx, s.URL, payload, withProxy(s.ProxyURL), withCertPool(s.CertPool),
+		withRequestOption(func(req *retryablehttp.Request) {
+			req.Header.Set("Authorization", "GenieKey "+s.ApiKey)
+		}),
+	)
 
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)

--- a/internal/notifier/pagerduty.go
+++ b/internal/notifier/pagerduty.go
@@ -55,14 +55,14 @@ func (p *PagerDuty) Post(ctx context.Context, event eventv1.Event) error {
 		return nil
 	}
 	e := toPagerDutyV2Event(event, p.RoutingKey)
-	err := postMessage(ctx, p.Endpoint+"/v2/enqueue", p.ProxyURL, p.CertPool, e)
+	err := postMessage(ctx, p.Endpoint+"/v2/enqueue", e, withProxy(p.ProxyURL), withCertPool(p.CertPool))
 	if err != nil {
 		return fmt.Errorf("failed sending event: %w", err)
 	}
 	// Send a change event for info events
 	if event.Severity == eventv1.EventSeverityInfo {
 		ce := toPagerDutyChangeEvent(event, p.RoutingKey)
-		err = postMessage(ctx, p.Endpoint+"/v2/change/enqueue", p.ProxyURL, p.CertPool, ce)
+		err = postMessage(ctx, p.Endpoint+"/v2/change/enqueue", ce, withProxy(p.ProxyURL), withCertPool(p.CertPool))
 		if err != nil {
 			return fmt.Errorf("failed sending change event: %w", err)
 		}

--- a/internal/notifier/rocket.go
+++ b/internal/notifier/rocket.go
@@ -83,7 +83,7 @@ func (s *Rocket) Post(ctx context.Context, event eventv1.Event) error {
 
 	payload.Attachments = []SlackAttachment{a}
 
-	err := postMessage(ctx, s.URL, s.ProxyURL, s.CertPool, payload)
+	err := postMessage(ctx, s.URL, payload, withProxy(s.ProxyURL), withCertPool(s.CertPool))
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}

--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -118,11 +118,14 @@ func (s *Slack) Post(ctx context.Context, event eventv1.Event) error {
 
 	payload.Attachments = []SlackAttachment{a}
 
-	err := postMessage(ctx, s.URL, s.ProxyURL, s.CertPool, payload, func(request *retryablehttp.Request) {
-		if s.Token != "" {
-			request.Header.Add("Authorization", "Bearer "+s.Token)
-		}
-	})
+	err := postMessage(
+		ctx, s.URL, payload, withProxy(s.ProxyURL), withCertPool(s.CertPool),
+		withRequestOption(func(request *retryablehttp.Request) {
+			if s.Token != "" {
+				request.Header.Add("Authorization", "Bearer "+s.Token)
+			}
+		}),
+	)
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}

--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -17,9 +17,13 @@ limitations under the License.
 package notifier
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -118,16 +122,48 @@ func (s *Slack) Post(ctx context.Context, event eventv1.Event) error {
 
 	payload.Attachments = []SlackAttachment{a}
 
-	err := postMessage(
-		ctx, s.URL, payload, withProxy(s.ProxyURL), withCertPool(s.CertPool),
+	messageOpts := []messageOption{
+		withProxy(s.ProxyURL),
+		withCertPool(s.CertPool),
 		withRequestOption(func(request *retryablehttp.Request) {
 			if s.Token != "" {
 				request.Header.Add("Authorization", "Bearer "+s.Token)
 			}
 		}),
-	)
+	}
+	if s.URL == "https://slack.com/api/chat.postMessage" {
+		messageOpts = append(messageOpts, withValidateResponse(s.validateResponse))
+	}
+
+	err := postMessage(ctx, s.URL, payload, messageOpts...)
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}
 	return nil
+}
+
+// validateResponse validates that a chat.postMessage API response is successful.
+// chat.postMessage API always returns 200 OK.
+// See https://api.slack.com/methods/chat.postMessage.
+//
+// On the other hand, incoming webhooks return more expressive HTTP status codes.
+// See https://api.slack.com/messaging/webhooks#handling_errors.
+func (s *Slack) validateResponse(resp *http.Response) bool {
+	// Clone resp.Body so it can be read again in postMessage error handling.
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false
+	}
+	resp.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	type slackResponse struct {
+		Ok bool `json:"ok"`
+	}
+	slackResp := slackResponse{}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return false
+	}
+
+	return slackResp.Ok
 }

--- a/internal/notifier/teams.go
+++ b/internal/notifier/teams.go
@@ -161,7 +161,7 @@ func (s *MSTeams) Post(ctx context.Context, event eventv1.Event) error {
 		payload = buildMSTeamsAdaptiveCardPayload(&event, objName)
 	}
 
-	err := postMessage(ctx, s.URL, s.ProxyURL, s.CertPool, payload)
+	err := postMessage(ctx, s.URL, payload, withProxy(s.ProxyURL), withCertPool(s.CertPool))
 	if err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}

--- a/internal/notifier/webex.go
+++ b/internal/notifier/webex.go
@@ -108,9 +108,12 @@ func (s *Webex) Post(ctx context.Context, event eventv1.Event) error {
 		Markdown: s.CreateMarkdown(&event),
 	}
 
-	if err := postMessage(ctx, s.URL, s.ProxyURL, s.CertPool, payload, func(request *retryablehttp.Request) {
-		request.Header.Add("Authorization", "Bearer "+s.Token)
-	}); err != nil {
+	if err := postMessage(
+		ctx, s.URL, payload, withProxy(s.ProxyURL), withCertPool(s.CertPool),
+		withRequestOption(func(request *retryablehttp.Request) {
+			request.Header.Add("Authorization", "Bearer "+s.Token)
+		}),
+	); err != nil {
 		return fmt.Errorf("postMessage failed: %w", err)
 	}
 	return nil


### PR DESCRIPTION
Fixes #1048 

This pull request fixes the error handling of Slack `chat.postMessage` API.
The API always returns `200 OK`, so we need to inspect the response body indicating whether the request succeeded or not.

This pull request is still in draft -- I am going to add a test for this change.
But before that, I would like some comments on whether this implementation direction is good.