### PR TITLE
feat: add 'proxyURL' support to Gitea notifier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/cdevents/sdk-go v0.4.1
 	github.com/chainguard-dev/git-urls v1.0.2
 	github.com/containrrr/shoutrrr v0.8.0
+	github.com/elazarl/goproxy v1.7.2
 	github.com/fluxcd/cli-utils v0.36.0-flux.12
 	github.com/fluxcd/notification-controller/api v1.5.0
 	github.com/fluxcd/pkg/apis/event v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TR
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
+github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -313,7 +313,7 @@ func giteaNotifierFunc(opts notifierOptions) (Interface, error) {
 	if opts.Token == "" && opts.Password != "" {
 		opts.Token = opts.Password
 	}
-	return NewGitea(opts.CommitStatus, opts.URL, opts.Token, opts.CertPool)
+	return NewGitea(opts.CommitStatus, opts.URL, opts.ProxyURL, opts.Token, opts.CertPool)
 }
 
 func bitbucketServerNotifierFunc(opts notifierOptions) (Interface, error) {

--- a/internal/notifier/gitea.go
+++ b/internal/notifier/gitea.go
@@ -45,7 +45,7 @@ type Gitea struct {
 
 var _ Interface = &Gitea{}
 
-func NewGitea(commitStatus string, addr string, token string, certPool *x509.CertPool) (*Gitea, error) {
+func NewGitea(commitStatus string, addr string, proxyURL string, token string, certPool *x509.CertPool) (*Gitea, error) {
 	if len(token) == 0 {
 		return nil, errors.New("gitea token cannot be empty")
 	}
@@ -74,6 +74,14 @@ func NewGitea(commitStatus string, addr string, token string, certPool *x509.Cer
 		tr.TLSClientConfig = &tls.Config{
 			RootCAs: certPool,
 		}
+	}
+
+	if proxyURL != "" {
+		parsedProxyURL, err := url.Parse(proxyURL)
+		if err != nil {
+			return nil, errors.New("invalid proxy URL")
+		}
+		tr.Proxy = http.ProxyURL(parsedProxyURL)
 	}
 
 	client, err := gitea.NewClient(host, gitea.SetToken(token), gitea.SetHTTPClient(&http.Client{Transport: tr}))

--- a/tests/listener/listener.go
+++ b/tests/listener/listener.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testlistener
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// New creates a TCP listener on a random port and returns
+// the listener, the address and the port of this listener.
+// It also registers a cleanup function to close the listener
+// when the test ends.
+func New(t *testing.T) (net.Listener, string, int) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	assert.NoError(t, err)
+	t.Cleanup(func() { lis.Close() })
+
+	addr := lis.Addr().String()
+	addrParts := strings.Split(addr, ":")
+	portStr := addrParts[len(addrParts)-1]
+	port, err := strconv.Atoi(portStr)
+	assert.NoError(t, err)
+
+	return lis, addr, port
+}

--- a/tests/proxy/proxy.go
+++ b/tests/proxy/proxy.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testproxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/elazarl/goproxy"
+
+	testlistener "github.com/fluxcd/notification-controller/tests/listener"
+)
+
+// New creates a new goproxy server on a random port and returns
+// the address and the port of this server. It also registers a
+// cleanup functions to close the server and the listener when
+// the test ends.
+func New(t *testing.T) (string, int) {
+	t.Helper()
+
+	lis, addr, port := testlistener.New(t)
+
+	handler := goproxy.NewProxyHttpServer()
+	handler.Verbose = true
+
+	server := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+	go server.Serve(lis)
+	t.Cleanup(func() { server.Close() })
+
+	return addr, port
+}


### PR DESCRIPTION
As was mentioned [here](https://github.com/fluxcd/notification-controller/pull/1084#pullrequestreview-2709351090) we're missing the proxy setting for Gitea. This PR introduces support for Gitea 'proxyURL'.