### PR TITLE
CrossNamespaceObjectReference: Fix MaxLength validation to k8s max 253 char

### DIFF
--- a/api/v1/reference_types.go
+++ b/api/v1/reference_types.go
@@ -31,13 +31,13 @@ type CrossNamespaceObjectReference struct {
 	// Name of the referent
 	// If multiple resources are targeted `*` may be set.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=53
+	// +kubebuilder:validation:MaxLength=253
 	// +required
 	Name string `json:"name"`
 
 	// Namespace of the referent
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=53
+	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Optional
 	// +optional
 	Namespace string `json:"namespace,omitempty"`

--- a/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
@@ -302,12 +302,12 @@ spec:
                       description: |-
                         Name of the referent
                         If multiple resources are targeted `*` may be set.
-                      maxLength: 53
+                      maxLength: 253
                       minLength: 1
                       type: string
                     namespace:
                       description: Namespace of the referent
-                      maxLength: 53
+                      maxLength: 253
                       minLength: 1
                       type: string
                   required:
@@ -519,12 +519,12 @@ spec:
                       description: |-
                         Name of the referent
                         If multiple resources are targeted `*` may be set.
-                      maxLength: 53
+                      maxLength: 253
                       minLength: 1
                       type: string
                     namespace:
                       description: Namespace of the referent
-                      maxLength: 53
+                      maxLength: 253
                       minLength: 1
                       type: string
                   required:

--- a/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
@@ -109,12 +109,12 @@ spec:
                       description: |-
                         Name of the referent
                         If multiple resources are targeted `*` may be set.
-                      maxLength: 53
+                      maxLength: 253
                       minLength: 1
                       type: string
                     namespace:
                       description: Namespace of the referent
-                      maxLength: 53
+                      maxLength: 253
                       minLength: 1
                       type: string
                   required:
@@ -536,12 +536,12 @@ spec:
                       description: |-
                         Name of the referent
                         If multiple resources are targeted `*` may be set.
-                      maxLength: 53
+                      maxLength: 253
                       minLength: 1
                       type: string
                     namespace:
                       description: Namespace of the referent
-                      maxLength: 53
+                      maxLength: 253
                       minLength: 1
                       type: string
                   required:


### PR DESCRIPTION
CrossNamespaceObjectReference should limit reference names to 253, which is the limit for `.metadata.name` and `.metadata.namespace`, ref https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names