### PR TITLE
Reintroduce default state machine for Provider controller

### DIFF
--- a/internal/controller/finalizer_predicate.go
+++ b/internal/controller/finalizer_predicate.go
@@ -28,7 +28,6 @@ import (
 // that have the flux finalizer.
 type finalizerPredicate struct {
 	predicate.Funcs
-	observeDeletion bool
 }
 
 // Create allows events for objects with flux finalizer that have beed created.
@@ -46,6 +45,6 @@ func (finalizerPredicate) Update(e event.UpdateEvent) bool {
 
 // Delete allows events for objects with flux finalizer that have been marked
 // for deletion.
-func (f finalizerPredicate) Delete(e event.DeleteEvent) bool {
-	return f.observeDeletion || controllerutil.ContainsFinalizer(e.Object, apiv1.NotificationFinalizer)
+func (finalizerPredicate) Delete(e event.DeleteEvent) bool {
+	return controllerutil.ContainsFinalizer(e.Object, apiv1.NotificationFinalizer)
 }

--- a/internal/controller/provider_predicate.go
+++ b/internal/controller/provider_predicate.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	apiv1 "github.com/fluxcd/notification-controller/api/v1"
+	apiv1beta3 "github.com/fluxcd/notification-controller/api/v1beta3"
+)
+
+// providerPredicate implements predicate functions for the Provider API.
+type providerPredicate struct{}
+
+func (providerPredicate) Create(e event.CreateEvent) bool {
+	return !controllerutil.ContainsFinalizer(e.Object, apiv1.NotificationFinalizer)
+}
+
+func (providerPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectNew == nil {
+		return false
+	}
+	return !controllerutil.ContainsFinalizer(e.ObjectNew, apiv1.NotificationFinalizer) ||
+		!e.ObjectNew.(*apiv1beta3.Provider).ObjectMeta.DeletionTimestamp.IsZero()
+}
+
+func (providerPredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (providerPredicate) Generic(e event.GenericEvent) bool {
+	return !controllerutil.ContainsFinalizer(e.Object, apiv1.NotificationFinalizer)
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -82,9 +82,8 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := (&ProviderReconciler{
-		Client:         testEnv,
-		ControllerName: controllerName,
-		EventRecorder:  testEnv.GetEventRecorderFor(controllerName),
+		Client:        testEnv,
+		EventRecorder: testEnv.GetEventRecorderFor(controllerName),
 	}).SetupWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Failed to start ProviderReconciler: %v", err))
 	}

--- a/main.go
+++ b/main.go
@@ -196,10 +196,9 @@ func main() {
 	}
 
 	if err = (&controller.ProviderReconciler{
-		Client:         mgr.GetClient(),
-		ControllerName: controllerName,
-		EventRecorder:  mgr.GetEventRecorderFor(controllerName),
-		TokenCache:     tokenCache,
+		Client:        mgr.GetClient(),
+		EventRecorder: mgr.GetEventRecorderFor(controllerName),
+		TokenCache:    tokenCache,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Provider")
 		os.Exit(1)


### PR DESCRIPTION
After introducing the token cache the Provider controller now has a reason to keep a finalizer at all times and use it in order to cleanup the token cache when a Provider object is deleted. So instead of being a controller that tries to remove the finalizer all the time, it's now again a controller that tries to add the finalizer all the time until deletion is observed.