### PR TITLE
Add mTLS support for postMessage-based notifiers

### DIFF
--- a/api/v1beta3/provider_types.go
+++ b/api/v1beta3/provider_types.go
@@ -123,12 +123,17 @@ type ProviderSpec struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
-	// CertSecretRef specifies the Secret containing
-	// a PEM-encoded CA certificate (in the `ca.crt` key).
-	// +optional
+	// CertSecretRef specifies the Secret containing TLS certificates
+	// for secure communication.
 	//
-	// Note: Support for the `caFile` key has
-	// been deprecated.
+	// Supported configurations:
+	// - CA-only: Server authentication (provide ca.crt only)
+	// - mTLS: Mutual authentication (provide ca.crt + tls.crt + tls.key)
+	// - Client-only: Client authentication with system CA (provide tls.crt + tls.key only)
+	//
+	// Legacy keys "caFile", "certFile", "keyFile" are supported but deprecated. Use "ca.crt", "tls.crt", "tls.key" instead.
+	//
+	// +optional
 	CertSecretRef *meta.LocalObjectReference `json:"certSecretRef,omitempty"`
 
 	// Suspend tells the controller to suspend subsequent

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -443,11 +443,15 @@ spec:
                 type: string
               certSecretRef:
                 description: |-
-                  CertSecretRef specifies the Secret containing
-                  a PEM-encoded CA certificate (in the `ca.crt` key).
+                  CertSecretRef specifies the Secret containing TLS certificates
+                  for secure communication.
 
-                  Note: Support for the `caFile` key has
-                  been deprecated.
+                  Supported configurations:
+                  - CA-only: Server authentication (provide ca.crt only)
+                  - mTLS: Mutual authentication (provide ca.crt + tls.crt + tls.key)
+                  - Client-only: Client authentication with system CA (provide tls.crt + tls.key only)
+
+                  Legacy keys "caFile", "certFile", "keyFile" are supported but deprecated. Use "ca.crt", "tls.crt", "tls.key" instead.
                 properties:
                   name:
                     description: Name of the referent.

--- a/docs/api/v1beta3/notification.md
+++ b/docs/api/v1beta3/notification.md
@@ -392,10 +392,13 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>CertSecretRef specifies the Secret containing
-a PEM-encoded CA certificate (in the <code>ca.crt</code> key).</p>
-<p>Note: Support for the <code>caFile</code> key has
-been deprecated.</p>
+<p>CertSecretRef specifies the Secret containing TLS certificates
+for secure communication.</p>
+<p>Supported configurations:
+- CA-only: Server authentication (provide ca.crt only)
+- mTLS: Mutual authentication (provide ca.crt + tls.crt + tls.key)
+- Client-only: Client authentication with system CA (provide tls.crt + tls.key only)</p>
+<p>Legacy keys &ldquo;caFile&rdquo;, &ldquo;certFile&rdquo;, &ldquo;keyFile&rdquo; are supported but deprecated. Use &ldquo;ca.crt&rdquo;, &ldquo;tls.crt&rdquo;, &ldquo;tls.key&rdquo; instead.</p>
 </td>
 </tr>
 <tr>
@@ -730,10 +733,13 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>CertSecretRef specifies the Secret containing
-a PEM-encoded CA certificate (in the <code>ca.crt</code> key).</p>
-<p>Note: Support for the <code>caFile</code> key has
-been deprecated.</p>
+<p>CertSecretRef specifies the Secret containing TLS certificates
+for secure communication.</p>
+<p>Supported configurations:
+- CA-only: Server authentication (provide ca.crt only)
+- mTLS: Mutual authentication (provide ca.crt + tls.crt + tls.key)
+- Client-only: Client authentication with system CA (provide tls.crt + tls.key only)</p>
+<p>Legacy keys &ldquo;caFile&rdquo;, &ldquo;certFile&rdquo;, &ldquo;keyFile&rdquo; are supported but deprecated. Use &ldquo;ca.crt&rdquo;, &ldquo;tls.crt&rdquo;, &ldquo;tls.key&rdquo; instead.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta3/providers.md
+++ b/docs/spec/v1beta3/providers.md
@@ -284,7 +284,7 @@ field](https://api.slack.com/methods/chat.postMessage#arg_username) to the
 payload, defaulting to the name of the reporting controller.
 
 This Provider type supports the configuration of a [proxy URL](#https-proxy)
-and/or [TLS certificates](#tls-certificates).
+and/or [certificate secret reference](#certificate-secret-reference).
 
 ###### Slack example
 
@@ -363,7 +363,7 @@ In both cases the Event metadata is attached as facts, and the involved object a
 The severity of the Event is used to set the color of the message.
 
 This Provider type supports the configuration of a [proxy URL](#https-proxy)
-and/or [TLS certificates](#tls-certificates), but lacks support for
+and/or [certificate secret reference](#certificate-secret-reference), but lacks support for
 configuring a [Channel](#channel). This can be configured during the
 creation of the Incoming Webhook Workflow in Microsoft Teams.
 
@@ -403,7 +403,7 @@ The Event will be formatted into a [DataDog Event](https://docs.datadoghq.com/ap
 API endpoint of the provided DataDog [Address](#address).
 
 This Provider type supports the configuration of a [proxy URL](#https-proxy)
-and/or [TLS certificates](#tls-certificates).
+and/or [certificate secret reference](#certificate-secret-reference).
 
 The metadata of the Event is included in the DataDog event as extra tags.
 
@@ -459,7 +459,7 @@ The Event will be formatted into a [Slack message](#slack) and send to the
 `/slack` endpoint of the provided Discord [Address](#address).
 
 This Provider type supports the configuration of a [proxy URL](#https-proxy)
-and/or [TLS certificates](#tls-certificates), but lacks support for
+and/or [certificate secret reference](#certificate-secret-reference), but lacks support for
 configuring a [Channel](#channel). This can be configured [during the creation
 of the address](https://discord.com/developers/docs/resources/webhook#create-webhook)
 
@@ -507,7 +507,7 @@ The Provider's [Channel](#channel) is used to set the `environment` on the
 Sentry client.
 
 This Provider type supports the configuration of
-[TLS certificates](#tls-certificates).
+[certificate secret reference](#certificate-secret-reference).
 
 ###### Sentry example
 
@@ -555,7 +555,7 @@ a unique identifier with the topic identifier (`-1234567890:1`) for the forum ch
 or the username (`@username`) of the target channel.
 
 This Provider type does not support the configuration of a [proxy URL](#https-proxy)
-or [TLS certificates](#tls-certificates).
+or [certificate secret reference](#certificate-secret-reference).
 
 ###### Telegram example
 
@@ -623,7 +623,7 @@ The Event will be formatted into a [Lark Message card](https://open.larksuite.co
 with the metadata written to the message string.
 
 This Provider type does not support the configuration of a [proxy URL](#https-proxy)
-or [TLS certificates](#tls-certificates).
+or [certificate secret reference](#certificate-secret-reference).
 
 ###### Lark example
 
@@ -660,7 +660,7 @@ The Event will be formatted into a [Slack message](#slack) and send as a
 payload the provided Rocket [Address](#address).
 
 This Provider type does support the configuration of a [proxy URL](#https-proxy)
-and [TLS certificates](#tls-certificates).
+and [certificate secret reference](#certificate-secret-reference).
 
 ###### Rocket example
 
@@ -742,7 +742,7 @@ You can optionally add [attributes](https://cloud.google.com/pubsub/docs/samples
 to the Pub/Sub message using a [`headers` key in the referenced Secret](#http-headers-example).
 
 This Provider type does not support the configuration of a [proxy URL](#https-proxy)
-or [TLS certificates](#tls-certificates).
+or [certificate secret reference](#certificate-secret-reference).
 
 ###### Google Pub/Sub with JSON Credentials and Custom Headers Example
 
@@ -788,7 +788,7 @@ with the metadata added to the [`details` field](https://docs.opsgenie.com/docs/
 as a list of key-value pairs.
 
 This Provider type does support the configuration of a [proxy URL](#https-proxy)
-and [TLS certificates](#tls-certificates).
+and [certificate secret reference](#certificate-secret-reference).
 
 ###### Opsgenie example
 
@@ -831,7 +831,7 @@ The provider will also send [Change Events](https://developer.pagerduty.com/api-
 for `info` level `Severity`, which will be displayed in the PagerDuty service's timeline to track changes.
 
 This Provider type supports the configuration of a [proxy URL](#https-proxy)
-and [TLS certificates](#tls-certificates).
+and [certificate secret reference](#certificate-secret-reference).
 
 The [Channel](#channel) is used to set the routing key to send the event to the appropriate integration.
 
@@ -916,7 +916,7 @@ global:
 ```
 
 This Provider type does support the configuration of a [proxy URL](#https-proxy)
-and [TLS certificates](#tls-certificates).
+and [certificate secret reference](#certificate-secret-reference).
 
 ###### Prometheus Alertmanager example
 
@@ -988,7 +988,7 @@ The [Channel](#channel) is used to set the ID of the room to send the message
 to.
 
 This Provider type does support the configuration of a [proxy URL](#https-proxy)
-and [TLS certificates](#tls-certificates).
+and [certificate secret reference](#certificate-secret-reference).
 
 ###### Webex example
 
@@ -1184,11 +1184,36 @@ stringData:
   proxy: "http://username:password@proxy_url:proxy_port"
 ```
 
-### TLS certificates
+### Certificate secret reference
 
 `.spec.certSecretRef` is an optional field to specify a name reference to a
-Secret in the same namespace as the Provider, containing the TLS CA certificate.
-The secret must be of type `kubernetes.io/tls` or `Opaque`.
+Secret in the same namespace as the Provider, containing TLS certificates for
+secure communication. The secret must be of type `kubernetes.io/tls` or `Opaque`.
+
+#### Supported configurations
+
+- **CA-only**: Server authentication (provide `ca.crt` only)
+- **mTLS**: Client certificate authentication (provide `tls.crt` + `tls.key`, optionally with `ca.crt`)
+
+#### Providers supporting client certificate authentication
+
+The following webhook-based providers support client certificate authentication:
+
+| Provider Type        | Description                    |
+|---------------------|--------------------------------|
+| `alertmanager`      | Prometheus Alertmanager        |
+| `discord`           | Discord webhooks               |
+| `forwarder`         | Generic forwarder              |
+| `grafana`           | Grafana annotations API        |
+| `matrix`            | Matrix rooms                   |
+| `msteams`           | Microsoft Teams                |
+| `opsgenie`          | Opsgenie alerts                |
+| `pagerduty`         | PagerDuty events               |
+| `rocket`            | Rocket.Chat                    |
+| `slack`             | Slack API                      |
+| `webex`             | Webex messages                 |
+
+Support for client certificate authentication is being expanded to additional providers over time.
 
 #### Example
 

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/fluxcd/pkg/cache v0.9.0
 	github.com/fluxcd/pkg/git v0.31.0
 	github.com/fluxcd/pkg/masktoken v0.7.0
-	github.com/fluxcd/pkg/runtime v0.61.0
+	github.com/fluxcd/pkg/runtime v0.63.0
 	github.com/fluxcd/pkg/ssa v0.48.0
 	github.com/fluxcd/pkg/ssh v0.18.0
 	github.com/getsentry/sentry-go v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/fluxcd/pkg/git v0.31.0 h1:hVUJcRujNa+GA5zrjrMpuVcgHbCBjfq0CZIZJqJl22I
 github.com/fluxcd/pkg/git v0.31.0/go.mod h1:rUgLXVQGBkBggHOLVMhHMHaweQ8Oc6HwZiN2Zm08Zxs=
 github.com/fluxcd/pkg/masktoken v0.7.0 h1:pitmyOg2pUVdW+nn2Lk/xqm2TaA08uxvOC0ns3sz6bM=
 github.com/fluxcd/pkg/masktoken v0.7.0/go.mod h1:Lc1uoDjO1GY6+YdkK+ZqqBIBWquyV58nlSJ5S1N1IYU=
-github.com/fluxcd/pkg/runtime v0.61.0 h1:63OCvVoJd3RbmAl7UBUzOeNtaY5V1iVL+SaaqiNMM74=
-github.com/fluxcd/pkg/runtime v0.61.0/go.mod h1:UeU0/eZLErYC/1bTmgzBfNXhiHy9fuQzjfLK0HxRgxY=
+github.com/fluxcd/pkg/runtime v0.63.0 h1:55J7ascGmXyTXWGwhD21N9fU7jC1l5rhdzjgNXs6aZg=
+github.com/fluxcd/pkg/runtime v0.63.0/go.mod h1:7pxGvaU0Yy1cDIUhiHAHhCx2yCLnkcVsplbYZG6j4JY=
 github.com/fluxcd/pkg/ssa v0.48.0 h1:DW+4DG8L/yZEi30UltOEXPB1d/ZFn4HfVhpJQp5oc2o=
 github.com/fluxcd/pkg/ssa v0.48.0/go.mod h1:T50TO0U2obLodZnrFgOrxollfBEy4V673OkM2aTUF1c=
 github.com/fluxcd/pkg/ssh v0.18.0 h1:SB0RrZ/YZIla3chTUulsfVmiCzJv5pEWfHM3dHMC8AU=

--- a/internal/notifier/alertmanager_fuzz_test.go
+++ b/internal/notifier/alertmanager_fuzz_test.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -43,10 +43,10 @@ func Fuzz_AlertManager(f *testing.F) {
 		}))
 		defer ts.Close()
 
-		var cert x509.CertPool
-		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
+		var tlsConfig tls.Config
+		_ = fuzz.NewConsumer(seed).GenerateStruct(&tlsConfig)
 
-		alertmanager, err := NewAlertmanager(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", &cert, "")
+		alertmanager, err := NewAlertmanager(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", &tlsConfig, "")
 		if err != nil {
 			return
 		}

--- a/internal/notifier/client_test.go
+++ b/internal/notifier/client_test.go
@@ -18,6 +18,7 @@ package notifier
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -80,7 +81,8 @@ func Test_postSelfSignedCert(t *testing.T) {
 	require.NoError(t, err)
 	certpool := x509.NewCertPool()
 	certpool.AddCert(cert)
-	err = postMessage(context.Background(), ts.URL, map[string]string{"status": "success"}, withCertPool(certpool))
+	tlsConfig := &tls.Config{RootCAs: certpool}
+	err = postMessage(context.Background(), ts.URL, map[string]string{"status": "success"}, withTLSConfig(tlsConfig))
 	require.NoError(t, err)
 }
 

--- a/internal/notifier/forwarder_fuzz_test.go
+++ b/internal/notifier/forwarder_fuzz_test.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -41,13 +41,13 @@ func Fuzz_Forwarder(f *testing.F) {
 		}))
 		defer ts.Close()
 
-		var cert x509.CertPool
-		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
+		var tlsConfig tls.Config
+		_ = fuzz.NewConsumer(seed).GenerateStruct(&tlsConfig)
 
 		header := make(map[string]string)
 		_ = fuzz.NewConsumer(seed).FuzzMap(&header)
 
-		forwarder, err := NewForwarder(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", header, &cert, hmacKey)
+		forwarder, err := NewForwarder(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", header, &tlsConfig, hmacKey)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/grafana.go
+++ b/internal/notifier/grafana.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"fmt"
 	"net/url"
 	"strings"
@@ -28,12 +28,12 @@ import (
 )
 
 type Grafana struct {
-	URL      string
-	Token    string
-	ProxyURL string
-	CertPool *x509.CertPool
-	Username string
-	Password string
+	URL       string
+	Token     string
+	ProxyURL  string
+	TLSConfig *tls.Config
+	Username  string
+	Password  string
 }
 
 // GraphitePayload represents a Grafana API annotation in Graphite format
@@ -44,19 +44,19 @@ type GraphitePayload struct {
 }
 
 // NewGrafana validates the Grafana URL and returns a Grafana object
-func NewGrafana(URL string, proxyURL string, token string, certPool *x509.CertPool, username string, password string) (*Grafana, error) {
+func NewGrafana(URL string, proxyURL string, token string, tlsConfig *tls.Config, username string, password string) (*Grafana, error) {
 	_, err := url.ParseRequestURI(URL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Grafana URL %s", URL)
 	}
 
 	return &Grafana{
-		URL:      URL,
-		ProxyURL: proxyURL,
-		Token:    token,
-		CertPool: certPool,
-		Username: username,
-		Password: password,
+		URL:       URL,
+		ProxyURL:  proxyURL,
+		Token:     token,
+		Username:  username,
+		Password:  password,
+		TLSConfig: tlsConfig,
 	}, nil
 }
 
@@ -97,8 +97,8 @@ func (g *Grafana) Post(ctx context.Context, event eventv1.Event) error {
 	if g.ProxyURL != "" {
 		opts = append(opts, withProxy(g.ProxyURL))
 	}
-	if g.CertPool != nil {
-		opts = append(opts, withCertPool(g.CertPool))
+	if g.TLSConfig != nil {
+		opts = append(opts, withTLSConfig(g.TLSConfig))
 	}
 
 	if err := postMessage(ctx, g.URL, payload, opts...); err != nil {

--- a/internal/notifier/grafana_fuzz_test.go
+++ b/internal/notifier/grafana_fuzz_test.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -43,10 +43,10 @@ func Fuzz_Grafana(f *testing.F) {
 		}))
 		defer ts.Close()
 
-		var cert x509.CertPool
-		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
+		var tlsConfig tls.Config
+		_ = fuzz.NewConsumer(seed).GenerateStruct(&tlsConfig)
 
-		grafana, err := NewGrafana(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", token, &cert, username, password)
+		grafana, err := NewGrafana(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", token, &tlsConfig, username, password)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/matrix_fuzz_test.go
+++ b/internal/notifier/matrix_fuzz_test.go
@@ -2,7 +2,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,10 +27,10 @@ func Fuzz_Matrix(f *testing.F) {
 		}))
 		defer ts.Close()
 
-		var cert x509.CertPool
-		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
+		var tlsConfig tls.Config
+		_ = fuzz.NewConsumer(seed).GenerateStruct(&tlsConfig)
 
-		matrix, err := NewMatrix(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, roomId, &cert)
+		matrix, err := NewMatrix(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, roomId, &tlsConfig)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/opsgenie_fuzz_test.go
+++ b/internal/notifier/opsgenie_fuzz_test.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,10 +42,10 @@ func Fuzz_OpsGenie(f *testing.F) {
 		}))
 		defer ts.Close()
 
-		var cert x509.CertPool
-		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
+		var tlsConfig tls.Config
+		_ = fuzz.NewConsumer(seed).GenerateStruct(&tlsConfig)
 
-		opsgenie, err := NewOpsgenie(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", &cert, token)
+		opsgenie, err := NewOpsgenie(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", &tlsConfig, token)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/pagerduty.go
+++ b/internal/notifier/pagerduty.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"fmt"
 	"net/url"
 	"time"
@@ -33,10 +33,10 @@ type PagerDuty struct {
 	Endpoint   string
 	RoutingKey string
 	ProxyURL   string
-	CertPool   *x509.CertPool
+	TLSConfig  *tls.Config
 }
 
-func NewPagerDuty(endpoint string, proxyURL string, certPool *x509.CertPool, routingKey string) (*PagerDuty, error) {
+func NewPagerDuty(endpoint string, proxyURL string, tlsConfig *tls.Config, routingKey string) (*PagerDuty, error) {
 	URL, err := url.ParseRequestURI(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid PagerDuty endpoint URL %q: '%w'", endpoint, err)
@@ -45,7 +45,7 @@ func NewPagerDuty(endpoint string, proxyURL string, certPool *x509.CertPool, rou
 		Endpoint:   URL.Scheme + "://" + URL.Host,
 		RoutingKey: routingKey,
 		ProxyURL:   proxyURL,
-		CertPool:   certPool,
+		TLSConfig:  tlsConfig,
 	}, nil
 }
 
@@ -59,8 +59,8 @@ func (p *PagerDuty) Post(ctx context.Context, event eventv1.Event) error {
 	if p.ProxyURL != "" {
 		opts = append(opts, withProxy(p.ProxyURL))
 	}
-	if p.CertPool != nil {
-		opts = append(opts, withCertPool(p.CertPool))
+	if p.TLSConfig != nil {
+		opts = append(opts, withTLSConfig(p.TLSConfig))
 	}
 
 	if err := postMessage(

--- a/internal/notifier/pagerduty_fuzz_test.go
+++ b/internal/notifier/pagerduty_fuzz_test.go
@@ -2,7 +2,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -32,10 +32,10 @@ func Fuzz_PagerDuty(f *testing.F) {
 		ts := httptest.NewServer(mux)
 		defer ts.Close()
 
-		var cert x509.CertPool
-		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
+		var tlsConfig tls.Config
+		_ = fuzz.NewConsumer(seed).GenerateStruct(&tlsConfig)
 
-		pd, err := NewPagerDuty(ts.URL, "", &cert, routingKey)
+		pd, err := NewPagerDuty(ts.URL, "", &tlsConfig, routingKey)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/rocket.go
+++ b/internal/notifier/rocket.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"fmt"
 	"net/url"
 	"strings"
@@ -28,26 +28,26 @@ import (
 
 // Rocket holds the hook URL
 type Rocket struct {
-	URL      string
-	ProxyURL string
-	Username string
-	Channel  string
-	CertPool *x509.CertPool
+	URL       string
+	ProxyURL  string
+	Username  string
+	Channel   string
+	TLSConfig *tls.Config
 }
 
 // NewRocket validates the Rocket URL and returns a Rocket object
-func NewRocket(hookURL string, proxyURL string, certPool *x509.CertPool, username string, channel string) (*Rocket, error) {
+func NewRocket(hookURL string, proxyURL string, tlsConfig *tls.Config, username string, channel string) (*Rocket, error) {
 	_, err := url.ParseRequestURI(hookURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Rocket hook URL %s: '%w'", hookURL, err)
 	}
 
 	return &Rocket{
-		Channel:  channel,
-		URL:      hookURL,
-		ProxyURL: proxyURL,
-		Username: username,
-		CertPool: certPool,
+		Channel:   channel,
+		URL:       hookURL,
+		ProxyURL:  proxyURL,
+		Username:  username,
+		TLSConfig: tlsConfig,
 	}, nil
 }
 
@@ -87,8 +87,8 @@ func (s *Rocket) Post(ctx context.Context, event eventv1.Event) error {
 	if s.ProxyURL != "" {
 		opts = append(opts, withProxy(s.ProxyURL))
 	}
-	if s.CertPool != nil {
-		opts = append(opts, withCertPool(s.CertPool))
+	if s.TLSConfig != nil {
+		opts = append(opts, withTLSConfig(s.TLSConfig))
 	}
 
 	if err := postMessage(ctx, s.URL, payload, opts...); err != nil {

--- a/internal/notifier/rocket_fuzz_test.go
+++ b/internal/notifier/rocket_fuzz_test.go
@@ -18,7 +18,6 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,10 +41,7 @@ func Fuzz_Rocket(f *testing.F) {
 		}))
 		defer ts.Close()
 
-		var cert x509.CertPool
-		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
-
-		rocket, err := NewRocket(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", &cert, username, channel)
+		rocket, err := NewRocket(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", nil, username, channel)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/slack_fuzz_test.go
+++ b/internal/notifier/slack_fuzz_test.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -43,10 +43,10 @@ func Fuzz_Slack(f *testing.F) {
 		}))
 		defer ts.Close()
 
-		var cert x509.CertPool
-		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
+		var tlsConfig tls.Config
+		_ = fuzz.NewConsumer(seed).GenerateStruct(&tlsConfig)
 
-		slack, err := NewSlack(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", token, &cert, username, channel)
+		slack, err := NewSlack(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", token, &tlsConfig, username, channel)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/teams_fuzz_test.go
+++ b/internal/notifier/teams_fuzz_test.go
@@ -18,7 +18,6 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
 	"fmt"
 	"io"
 	"net/http"
@@ -43,10 +42,7 @@ func Fuzz_MSTeams(f *testing.F) {
 		}))
 		defer ts.Close()
 
-		var cert x509.CertPool
-		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
-
-		teams, err := NewMSTeams(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", &cert)
+		teams, err := NewMSTeams(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", nil)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/webex_fuzz_test.go
+++ b/internal/notifier/webex_fuzz_test.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,10 +42,10 @@ func Fuzz_Webex(f *testing.F) {
 		}))
 		defer ts.Close()
 
-		var cert x509.CertPool
-		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
+		var tlsConfig tls.Config
+		_ = fuzz.NewConsumer(seed).GenerateStruct(&tlsConfig)
 
-		webex, err := NewWebex(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", &cert, channel, token)
+		webex, err := NewWebex(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), "", &tlsConfig, channel, token)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
## Summary

Implements mutual TLS (mTLS) support for postMessage-based notifiers as part of https://github.com/fluxcd/flux2/issues/5433.

- Add mTLS support to 10 postMessage notifiers (Slack, Teams, Grafana, etc.)
- Unify constructor signatures with consistent tlsConfig parameter
- Make TLSConfig field public for consistency
- Update factory functions and fuzz tests
- Replace CertPool with TLSConfig using runtime/secrets

## Follow-up Work

This implementation covers postMessage-based notifiers. Future mTLS support can be added to:
- Git-based notifiers (GitHub, GitLab, Gitea, Bitbucket, Azure DevOps)
- Data notifiers (DataDog, Sentry)