### PR TITLE
Add proxy support to Telegram notifier

### DIFF
--- a/docs/spec/v1beta3/providers.md
+++ b/docs/spec/v1beta3/providers.md
@@ -554,8 +554,7 @@ This can be a unique identifier (`-1234567890`) for the target chat,
 a unique identifier with the topic identifier (`-1234567890:1`) for the forum chat,
 or the username (`@username`) of the target channel.
 
-This Provider type does not support the configuration of a [proxy URL](#https-proxy)
-or [certificate secret reference](#certificate-secret-reference).
+This Provider type does not support the configuration of a [certificate secret reference](#certificate-secret-reference).
 
 ###### Telegram example
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/PagerDuty/go-pagerduty v1.8.0
 	github.com/cdevents/sdk-go v0.4.1
 	github.com/chainguard-dev/git-urls v1.0.2
-	github.com/containrrr/shoutrrr v0.8.0
 	github.com/elazarl/goproxy v1.7.2
 	github.com/fluxcd/cli-utils v0.36.0-flux.13
 	github.com/fluxcd/notification-controller/api v1.6.0
@@ -99,7 +98,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
-	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.7.0 // indirect
 	github.com/fluxcd/pkg/apis/kustomize v1.10.0 // indirect
@@ -145,8 +143,6 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,6 @@ github.com/cloudevents/sdk-go/v2 v2.15.2/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/containrrr/shoutrrr v0.8.0 h1:mfG2ATzIS7NR2Ec6XL+xyoHzN97H8WPjir8aYzJUSec=
-github.com/containrrr/shoutrrr v0.8.0/go.mod h1:ioyQAyu1LJY6sILuNyKaQaw+9Ttik5QePU8atnAdO2o=
 github.com/coreos/go-oidc/v3 v3.14.1 h1:9ePWwfdwC4QKRlCXsJGou56adA/owXczOzwKdOumLqk=
 github.com/coreos/go-oidc/v3 v3.14.1/go.mod h1:HaZ3szPaZ0e4r6ebqvsLWlk2Tn+aejfmrfah6hnSYEU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -211,7 +209,6 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.22.0 h1:k6HsTZ0sTnROkhS//R0O+55JgM8C4Bx7ia+JlgcnOao=
 github.com/go-playground/validator/v10 v10.22.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
-github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
@@ -295,8 +292,6 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
-github.com/jarcoal/httpmock v1.3.0/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -330,7 +325,6 @@ github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/microsoft/azure-devops-go-api/azuredevops/v6 v6.0.1 h1:ACnM5CwgTH6OSQHErzZDrotEG0rffPdJxtF/WOWglAw=
@@ -514,9 +508,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -285,7 +285,7 @@ func azureEventHubNotifierFunc(opts notifierOptions) (Interface, error) {
 }
 
 func telegramNotifierFunc(opts notifierOptions) (Interface, error) {
-	return NewTelegram(opts.Channel, opts.Token)
+	return NewTelegram(opts.URL, opts.ProxyURL, opts.Channel, opts.Token)
 }
 
 func larkNotifierFunc(opts notifierOptions) (Interface, error) {

--- a/internal/notifier/telegram.go
+++ b/internal/notifier/telegram.go
@@ -4,27 +4,50 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
-	"github.com/containrrr/shoutrrr"
 	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
 )
 
+const (
+	defaultTelegramBaseURL = "https://api.telegram.org/bot%s"
+	sendMessageMethodName  = "sendMessage"
+)
+
 type Telegram struct {
-	Channel string
-	Token   string
-	send    func(url string, message string) error // this allows the send function to be overridden for testing
+	URL      string
+	ProxyURL string
+	Channel  string
+	Token    string
 }
 
-func NewTelegram(channel, token string) (*Telegram, error) {
+// TelegramPayload represents the payload sent to Telegram Bot API
+// Reference: https://core.telegram.org/bots/api#sendmessage
+type TelegramPayload struct {
+	ChatID    string `json:"chat_id"`    // Unique identifier for the target chat
+	Text      string `json:"text"`       // Text of the message to be sent
+	ParseMode string `json:"parse_mode"` // Mode for parsing entities in the message text
+}
+
+func NewTelegram(apiURL, proxyURL, channel, token string) (*Telegram, error) {
 	if channel == "" {
 		return nil, errors.New("empty Telegram channel")
 	}
 
+	if token == "" {
+		return nil, errors.New("empty Telegram token")
+	}
+
+	if apiURL == "" {
+		apiURL = fmt.Sprintf(defaultTelegramBaseURL, token)
+	}
+
 	return &Telegram{
-		Channel: channel,
-		Token:   token,
-		send:    shoutrrr.Send,
+		URL:      apiURL,
+		ProxyURL: proxyURL,
+		Channel:  channel,
+		Token:    token,
 	}, nil
 }
 
@@ -46,9 +69,24 @@ func (t *Telegram) Post(ctx context.Context, event eventv1.Event) error {
 		metadata = metadata + fmt.Sprintf("\\- *%s*: %s\n", escapeString(k), escapeString(v))
 	}
 	message := fmt.Sprintf("*%s*\n%s\n%s", escapeString(heading), escapeString(event.Message), metadata)
-	url := fmt.Sprintf("telegram://%s@telegram?channels=%s&parseMode=markDownv2", t.Token, t.Channel)
-	err := t.send(url, message)
-	return err
+
+	payload := TelegramPayload{
+		ChatID:    t.Channel,
+		Text:      message,
+		ParseMode: "MarkdownV2", // https://core.telegram.org/bots/api#markdownv2-style
+	}
+
+	apiURL, err := url.JoinPath(t.URL, sendMessageMethodName)
+	if err != nil {
+		return fmt.Errorf("failed to construct API URL: %w", err)
+	}
+
+	var opts []postOption
+	if t.ProxyURL != "" {
+		opts = append(opts, withProxy(t.ProxyURL))
+	}
+
+	return postMessage(ctx, apiURL, payload, opts...)
 }
 
 // The telegram API requires that some special characters are escaped

--- a/internal/notifier/telegram.go
+++ b/internal/notifier/telegram.go
@@ -39,9 +39,9 @@ func NewTelegram(apiURL, proxyURL, channel, token string) (*Telegram, error) {
 		return nil, errors.New("empty Telegram token")
 	}
 
-	if apiURL == "" {
-		apiURL = fmt.Sprintf(defaultTelegramBaseURL, token)
-	}
+	// Note: Always ignore apiURL parameter for backward compatibility.
+	// The address field was ignored until v1.6.0.
+	apiURL = fmt.Sprintf(defaultTelegramBaseURL, token)
 
 	return &Telegram{
 		URL:      apiURL,

--- a/internal/notifier/telegram_test.go
+++ b/internal/notifier/telegram_test.go
@@ -60,11 +60,27 @@ func TestTelegram_Post(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	telegram, err := NewTelegram(ts.URL, "", "channel", "token")
+	telegram, err := NewTelegram("", "", "channel", "token")
 	require.NoError(t, err)
+
+	telegram.URL = ts.URL
 
 	ev := testEvent()
 	ev.Metadata["kubernetes.io/somekey"] = "some.value"
 	err = telegram.Post(context.TODO(), ev)
 	require.NoError(t, err)
+}
+
+func TestTelegram_NewTelegram_IgnoresAddress(t *testing.T) {
+	telegram, err := NewTelegram("https://api.telegram.org", "", "channel", "token")
+	require.NoError(t, err)
+	require.Equal(t, "https://api.telegram.org/bottoken", telegram.URL)
+
+	telegram2, err := NewTelegram("https://custom.example.com", "", "channel", "token")
+	require.NoError(t, err)
+	require.Equal(t, "https://api.telegram.org/bottoken", telegram2.URL)
+
+	telegram3, err := NewTelegram("", "", "channel", "token")
+	require.NoError(t, err)
+	require.Equal(t, "https://api.telegram.org/bottoken", telegram3.URL)
 }


### PR DESCRIPTION
## Summary

Add proxy support to Telegram notifier by replacing shoutrrr with direct Telegram Bot API calls.

## Changes

- Replace shoutrrr.Send with postMessage function for proxy support
- Add ProxyURL field to Telegram struct
- Update v1beta3 documentation to remove proxy limitation

## Testing

Proxy functionality should work with ProxySecretRef added in #1133. Implementation follows existing patterns and should work in theory, but only verified through unit tests as I don't have a Telegram test environment.

Since this implementation uses the existing postMessage function for proxy handling, no additional proxy-specific tests were added.

Resolves #432