### PR TITLE
Fix double secret fetching in BasicAuth processing

### DIFF
--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -344,6 +344,13 @@ func extractAuthFromSecret(ctx context.Context, kubeClient client.Client, provid
 		options = append(options, notifier.WithHeaders(headers))
 	}
 
+	if user, ok := secret.Data["username"]; ok {
+		if pass, ok := secret.Data["password"]; ok {
+			options = append(options, notifier.WithUsername(strings.TrimSpace(string(user))))
+			options = append(options, notifier.WithPassword(strings.TrimSpace(string(pass))))
+		}
+	}
+
 	return options, secret.Data, nil
 }
 
@@ -403,12 +410,6 @@ func createNotifier(ctx context.Context, kubeClient client.Client, provider *api
 		}
 		if val, ok := secretData[secrets.TokenKey]; ok {
 			token = strings.TrimSpace(string(val))
-		}
-
-		user, pass, err := secrets.BasicAuthFromSecret(ctx, kubeClient, provider.Spec.SecretRef.Name, provider.Namespace)
-		if err == nil {
-			options = append(options, notifier.WithUsername(user))
-			options = append(options, notifier.WithPassword(pass))
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes a performance regression introduced in #1139 where `spec.secretRef` was being fetched twice.

## Problem

As pointed out by @matheuscscp in https://github.com/fluxcd/notification-controller/pull/1139#issuecomment-3056595416, the implementation was fetching the secret twice:
1. Once in `extractAuthFromSecret`
2. Again in `secrets.BasicAuthFromSecret`

Since notification-controller doesn't cache secrets by default, this has a significant performance impact.

## Solution

Following Option 1 from https://github.com/fluxcd/flux2/issues/5433#issuecomment-3031563739, this PR moves the BasicAuth processing directly into `extractAuthFromSecret` using the already-fetched secret data. This aligns with the special nature of `spec.secretRef` that contains multiple authentication methods.