### PR TITLE
Add mTLS support for git-based notifiers

### DIFF
--- a/docs/spec/v1beta3/providers.md
+++ b/docs/spec/v1beta3/providers.md
@@ -1197,13 +1197,20 @@ secure communication. The secret must be of type `kubernetes.io/tls` or `Opaque`
 
 #### Providers supporting client certificate authentication
 
-The following webhook-based providers support client certificate authentication:
+The following providers support client certificate authentication:
 
 | Provider Type        | Description                    |
 |---------------------|--------------------------------|
 | `alertmanager`      | Prometheus Alertmanager        |
+| `azuredevops`       | Azure DevOps                   |
+| `bitbucket`         | Bitbucket                      |
+| `bitbucketserver`   | BitBucket Server/Data Center   |
 | `discord`           | Discord webhooks               |
 | `forwarder`         | Generic forwarder              |
+| `gitea`             | Gitea                          |
+| `github`            | GitHub                         |
+| `githubdispatch`    | GitHub Dispatch                |
+| `gitlab`            | GitLab                         |
 | `grafana`           | Grafana annotations API        |
 | `matrix`            | Matrix rooms                   |
 | `msteams`           | Microsoft Teams                |

--- a/go.mod
+++ b/go.mod
@@ -18,12 +18,12 @@ require (
 	github.com/fluxcd/cli-utils v0.36.0-flux.14
 	github.com/fluxcd/notification-controller/api v1.6.0
 	github.com/fluxcd/pkg/apis/event v0.18.0
-	github.com/fluxcd/pkg/apis/meta v1.17.0
+	github.com/fluxcd/pkg/apis/meta v1.18.0
 	github.com/fluxcd/pkg/auth v0.21.0
 	github.com/fluxcd/pkg/cache v0.10.0
 	github.com/fluxcd/pkg/git v0.34.0
 	github.com/fluxcd/pkg/masktoken v0.7.0
-	github.com/fluxcd/pkg/runtime v0.69.0
+	github.com/fluxcd/pkg/runtime v0.74.0
 	github.com/fluxcd/pkg/ssa v0.51.0
 	github.com/fluxcd/pkg/ssh v0.20.0
 	github.com/getsentry/sentry-go v0.34.1

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/fluxcd/pkg/apis/event v0.18.0 h1:PNbWk9gvX8gMIi6VsJapnuDO+giLEeY+6olL
 github.com/fluxcd/pkg/apis/event v0.18.0/go.mod h1:7S/DGboLolfbZ6stO6dcDhG1SfkPWQ9foCULvbiYpiA=
 github.com/fluxcd/pkg/apis/kustomize v1.11.0 h1:0IzDgxZkc4v+5SDNCvgZhfwfkdkQLPXCner7TNaJFWE=
 github.com/fluxcd/pkg/apis/kustomize v1.11.0/go.mod h1:j302mJGDww8cn9qvMsRQ0LJ1HPAPs/IlX7CSsoJV7BI=
-github.com/fluxcd/pkg/apis/meta v1.17.0 h1:KVMDyJQj1NYCsppsFUkbJGMnKxsqJVpnKBFolHf/q8E=
-github.com/fluxcd/pkg/apis/meta v1.17.0/go.mod h1:97l3hTwBpJbXBY+wetNbqrUsvES8B1jGioKcBUxmqd8=
+github.com/fluxcd/pkg/apis/meta v1.18.0 h1:ACHrMIjlcioE9GKS7NGk62KX4NshqNewr8sBwMcXABs=
+github.com/fluxcd/pkg/apis/meta v1.18.0/go.mod h1:97l3hTwBpJbXBY+wetNbqrUsvES8B1jGioKcBUxmqd8=
 github.com/fluxcd/pkg/auth v0.21.0 h1:ckAQqP12wuptXEkMY18SQKWEY09m9e6yI0mEMsDV15M=
 github.com/fluxcd/pkg/auth v0.21.0/go.mod h1:MXmpsXT97c874HCw5hnfqFUP7TsG8/Ss1vFrk8JccfM=
 github.com/fluxcd/pkg/cache v0.10.0 h1:M+OGDM4da1cnz7q+sZSBtkBJHpiJsLnKVmR9OdMWxEY=
@@ -146,8 +146,8 @@ github.com/fluxcd/pkg/git v0.34.0 h1:qTViWkfpEDnjzySyKRKliqUeGj/DznqlkmPhaDNIsFY
 github.com/fluxcd/pkg/git v0.34.0/go.mod h1:F9Asm3MlLW4uZx3FF92+bqho+oktdMdnTn/QmXe56NE=
 github.com/fluxcd/pkg/masktoken v0.7.0 h1:pitmyOg2pUVdW+nn2Lk/xqm2TaA08uxvOC0ns3sz6bM=
 github.com/fluxcd/pkg/masktoken v0.7.0/go.mod h1:Lc1uoDjO1GY6+YdkK+ZqqBIBWquyV58nlSJ5S1N1IYU=
-github.com/fluxcd/pkg/runtime v0.69.0 h1:5gPY95NSFI34GlQTj0+NHjOFpirSwviCUb9bM09b5nA=
-github.com/fluxcd/pkg/runtime v0.69.0/go.mod h1:ug+pat+I4wfOBuCy2E/pLmBNd3kOOo4cP2jxnxefPwY=
+github.com/fluxcd/pkg/runtime v0.74.0 h1:4SxBWJSU6vKIrAoUHtaJ190pHyK445qlmIgG2XC5Tb0=
+github.com/fluxcd/pkg/runtime v0.74.0/go.mod h1:iGhdaEq+lMJQTJNAFEPOU4gUJ7kt3yeDcJPZy7O9IUw=
 github.com/fluxcd/pkg/ssa v0.51.0 h1:sFarxKZcS0J8sjq9qvs/r+1XiJqNgRodEiPjV75F8R4=
 github.com/fluxcd/pkg/ssa v0.51.0/go.mod h1:v+h9RC0JxWIqMTK2Eo+8Nh700AXyZChZ2TiLVj4tf3M=
 github.com/fluxcd/pkg/ssh v0.20.0 h1:Ak0laIYIc/L8lEfqls/LDWRW8wYPESGaravQsCRGLb8=

--- a/internal/notifier/azure_devops_fuzz_test.go
+++ b/internal/notifier/azure_devops_fuzz_test.go
@@ -18,6 +18,7 @@ package notifier
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -54,7 +55,8 @@ func Fuzz_AzureDevOps(f *testing.F) {
 		var cert x509.CertPool
 		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
 
-		azureDevOps, err := NewAzureDevOps(context.TODO(), commitStatus, fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, &cert, "", "", "", "", nil, nil)
+		tlsConfig := &tls.Config{RootCAs: &cert}
+		azureDevOps, err := NewAzureDevOps(context.TODO(), commitStatus, fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, tlsConfig, "", "", "", "", nil, nil)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/bitbucket.go
+++ b/internal/notifier/bitbucket.go
@@ -19,7 +19,6 @@ package notifier
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,7 +40,7 @@ type Bitbucket struct {
 }
 
 // NewBitbucket creates and returns a new Bitbucket notifier.
-func NewBitbucket(commitStatus string, addr string, token string, certPool *x509.CertPool) (*Bitbucket, error) {
+func NewBitbucket(commitStatus string, addr string, token string, tlsConfig *tls.Config) (*Bitbucket, error) {
 	if len(token) == 0 {
 		return nil, errors.New("bitbucket token cannot be empty")
 	}
@@ -71,11 +70,9 @@ func NewBitbucket(commitStatus string, addr string, token string, certPool *x509
 	repo := comp[1]
 
 	client := bitbucket.NewBasicAuth(username, password)
-	if certPool != nil {
+	if tlsConfig != nil {
 		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: certPool,
-			},
+			TLSClientConfig: tlsConfig,
 		}
 		hc := &http.Client{Transport: tr}
 		client.HttpClient = hc

--- a/internal/notifier/bitbucket_fuzz_test.go
+++ b/internal/notifier/bitbucket_fuzz_test.go
@@ -18,6 +18,7 @@ package notifier
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -45,7 +46,8 @@ func Fuzz_Bitbucket(f *testing.F) {
 		var cert x509.CertPool
 		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
 
-		bitbucket, err := NewBitbucket(commitStatus, fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, &cert)
+		tlsConfig := &tls.Config{RootCAs: &cert}
+		bitbucket, err := NewBitbucket(commitStatus, fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, tlsConfig)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/bitbucketserver.go
+++ b/internal/notifier/bitbucketserver.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -81,7 +80,7 @@ type bbServerBuildStatusSetRequest struct {
 }
 
 // NewBitbucketServer creates and returns a new BitbucketServer notifier.
-func NewBitbucketServer(commitStatus string, addr string, token string, certPool *x509.CertPool, username string, password string) (*BitbucketServer, error) {
+func NewBitbucketServer(commitStatus string, addr string, token string, tlsConfig *tls.Config, username string, password string) (*BitbucketServer, error) {
 	url, err := parseBitbucketServerGitAddress(addr)
 	if err != nil {
 		return nil, err
@@ -93,11 +92,9 @@ func NewBitbucketServer(commitStatus string, addr string, token string, certPool
 	}
 
 	httpClient := retryablehttp.NewClient()
-	if certPool != nil {
+	if tlsConfig != nil {
 		httpClient.HTTPClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: certPool,
-			},
+			TLSClientConfig: tlsConfig,
 		}
 	}
 

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -318,40 +318,40 @@ func gitHubNotifierFunc(opts notifierOptions) (Interface, error) {
 	if opts.Token == "" && opts.Password != "" {
 		opts.Token = opts.Password
 	}
-	return NewGitHub(opts.CommitStatus, opts.URL, opts.Token, opts.CertPool, opts.ProxyURL, opts.ProviderName, opts.ProviderNamespace, opts.SecretData, opts.TokenCache)
+	return NewGitHub(opts.CommitStatus, opts.URL, opts.Token, opts.TLSConfig, opts.ProxyURL, opts.ProviderName, opts.ProviderNamespace, opts.SecretData, opts.TokenCache)
 }
 
 func gitHubDispatchNotifierFunc(opts notifierOptions) (Interface, error) {
 	if opts.Token == "" && opts.Password != "" {
 		opts.Token = opts.Password
 	}
-	return NewGitHubDispatch(opts.URL, opts.Token, opts.CertPool, opts.ProxyURL, opts.ProviderName, opts.ProviderNamespace, opts.SecretData, opts.TokenCache)
+	return NewGitHubDispatch(opts.URL, opts.Token, opts.TLSConfig, opts.ProxyURL, opts.ProviderName, opts.ProviderNamespace, opts.SecretData, opts.TokenCache)
 }
 
 func gitLabNotifierFunc(opts notifierOptions) (Interface, error) {
 	if opts.Token == "" && opts.Password != "" {
 		opts.Token = opts.Password
 	}
-	return NewGitLab(opts.CommitStatus, opts.URL, opts.Token, opts.CertPool)
+	return NewGitLab(opts.CommitStatus, opts.URL, opts.Token, opts.TLSConfig)
 }
 
 func giteaNotifierFunc(opts notifierOptions) (Interface, error) {
 	if opts.Token == "" && opts.Password != "" {
 		opts.Token = opts.Password
 	}
-	return NewGitea(opts.CommitStatus, opts.URL, opts.ProxyURL, opts.Token, opts.CertPool)
+	return NewGitea(opts.CommitStatus, opts.URL, opts.ProxyURL, opts.Token, opts.TLSConfig)
 }
 
 func bitbucketServerNotifierFunc(opts notifierOptions) (Interface, error) {
-	return NewBitbucketServer(opts.CommitStatus, opts.URL, opts.Token, opts.CertPool, opts.Username, opts.Password)
+	return NewBitbucketServer(opts.CommitStatus, opts.URL, opts.Token, opts.TLSConfig, opts.Username, opts.Password)
 }
 
 func bitbucketNotifierFunc(opts notifierOptions) (Interface, error) {
-	return NewBitbucket(opts.CommitStatus, opts.URL, opts.Token, opts.CertPool)
+	return NewBitbucket(opts.CommitStatus, opts.URL, opts.Token, opts.TLSConfig)
 }
 
 func azureDevOpsNotifierFunc(opts notifierOptions) (Interface, error) {
 	return NewAzureDevOps(opts.Context, opts.CommitStatus, opts.URL, opts.Token,
-		opts.CertPool, opts.ProxyURL, opts.ServiceAccountName, opts.ProviderName,
+		opts.TLSConfig, opts.ProxyURL, opts.ServiceAccountName, opts.ProviderName,
 		opts.ProviderNamespace, opts.TokenClient, opts.TokenCache)
 }

--- a/internal/notifier/gitea.go
+++ b/internal/notifier/gitea.go
@@ -19,7 +19,6 @@ package notifier
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -45,7 +44,7 @@ type Gitea struct {
 
 var _ Interface = &Gitea{}
 
-func NewGitea(commitStatus string, addr string, proxyURL string, token string, certPool *x509.CertPool) (*Gitea, error) {
+func NewGitea(commitStatus string, addr string, proxyURL string, token string, tlsConfig *tls.Config) (*Gitea, error) {
 	if len(token) == 0 {
 		return nil, errors.New("gitea token cannot be empty")
 	}
@@ -70,10 +69,8 @@ func NewGitea(commitStatus string, addr string, proxyURL string, token string, c
 	}
 
 	tr := &http.Transport{}
-	if certPool != nil {
-		tr.TLSClientConfig = &tls.Config{
-			RootCAs: certPool,
-		}
+	if tlsConfig != nil {
+		tr.TLSClientConfig = tlsConfig
 	}
 
 	if proxyURL != "" {

--- a/internal/notifier/gitea_test.go
+++ b/internal/notifier/gitea_test.go
@@ -18,6 +18,7 @@ package notifier
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	testproxy "github.com/fluxcd/notification-controller/tests/proxy"
@@ -81,8 +82,9 @@ func TestNewGiteaWithCertPool(t *testing.T) {
 
 	certPool := x509.NewCertPool()
 	certPool.AddCert(srv.Certificate())
+	tlsConfig := &tls.Config{RootCAs: certPool}
 
-	g, err := NewGitea("kustomization/gitops-system/0c9c2e41", srv.URL+"/foo/bar", "", "foobar", certPool)
+	g, err := NewGitea("kustomization/gitops-system/0c9c2e41", srv.URL+"/foo/bar", "", "foobar", tlsConfig)
 	assert.NoError(t, err)
 	assert.Equal(t, g.Owner, "foo")
 	assert.Equal(t, g.Repo, "bar")
@@ -94,8 +96,9 @@ func TestNewGiteaNoCertificate(t *testing.T) {
 	defer srv.Close()
 
 	certPool := x509.NewCertPool()
+	tlsConfig := &tls.Config{RootCAs: certPool}
 
-	_, err := NewGitea("kustomization/gitops-system/0c9c2e41", srv.URL+"/foo/bar", "", "foobar", certPool)
+	_, err := NewGitea("kustomization/gitops-system/0c9c2e41", srv.URL+"/foo/bar", "", "foobar", tlsConfig)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "tls: failed to verify certificate: x509: certificate signed by unknown authority")
 }
@@ -119,11 +122,12 @@ func TestNewGiteaWithProxyURLAndCertPool(t *testing.T) {
 
 	certPool := x509.NewCertPool()
 	certPool.AddCert(srv.Certificate())
+	tlsConfig := &tls.Config{RootCAs: certPool}
 
 	proxyAddr, _ := testproxy.New(t)
 	proxyURL := fmt.Sprintf("http://%s", proxyAddr)
 
-	g, err := NewGitea("kustomization/gitops-system/0c9c2e41", srv.URL+"/foo/bar", proxyURL, "foobar", certPool)
+	g, err := NewGitea("kustomization/gitops-system/0c9c2e41", srv.URL+"/foo/bar", proxyURL, "foobar", tlsConfig)
 	assert.NoError(t, err)
 	assert.Equal(t, g.Owner, "foo")
 	assert.Equal(t, g.Repo, "bar")

--- a/internal/notifier/github.go
+++ b/internal/notifier/github.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"errors"
 	"fmt"
 
@@ -36,7 +36,7 @@ type GitHub struct {
 	Client       *github.Client
 }
 
-func NewGitHub(commitStatus string, addr string, token string, certPool *x509.CertPool,
+func NewGitHub(commitStatus string, addr string, token string, tlsConfig *tls.Config,
 	proxyURL string, providerName string, providerNamespace string, secretData map[string][]byte,
 	tokenCache *cache.TokenCache) (*GitHub, error) {
 
@@ -45,7 +45,7 @@ func NewGitHub(commitStatus string, addr string, token string, certPool *x509.Ce
 		return nil, errors.New("commit status cannot be empty")
 	}
 
-	repoInfo, err := getRepoInfoAndGithubClient(addr, token, certPool,
+	repoInfo, err := getRepoInfoAndGithubClient(addr, token, tlsConfig,
 		proxyURL, providerName, providerNamespace, secretData, tokenCache)
 	if err != nil {
 		return nil, err

--- a/internal/notifier/github_dispatch.go
+++ b/internal/notifier/github_dispatch.go
@@ -18,7 +18,7 @@ package notifier
 
 import (
 	"context"
-	"crypto/x509"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 
@@ -34,11 +34,11 @@ type GitHubDispatch struct {
 	Client *github.Client
 }
 
-func NewGitHubDispatch(addr string, token string, certPool *x509.CertPool, proxyURL string,
+func NewGitHubDispatch(addr string, token string, tlsConfig *tls.Config, proxyURL string,
 	providerName string, providerNamespace string, secretData map[string][]byte,
 	tokenCache *cache.TokenCache) (*GitHubDispatch, error) {
 
-	repoInfo, err := getRepoInfoAndGithubClient(addr, token, certPool,
+	repoInfo, err := getRepoInfoAndGithubClient(addr, token, tlsConfig,
 		proxyURL, providerName, providerNamespace, secretData, tokenCache)
 	if err != nil {
 		return nil, err

--- a/internal/notifier/github_dispatch_fuzz_test.go
+++ b/internal/notifier/github_dispatch_fuzz_test.go
@@ -18,6 +18,7 @@ package notifier
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -46,7 +47,8 @@ func Fuzz_GitHub_Dispatch(f *testing.F) {
 		var cert x509.CertPool
 		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
 
-		dispatch, err := NewGitHubDispatch(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, &cert, "", "", "", nil, nil)
+		tlsConfig := &tls.Config{RootCAs: &cert}
+		dispatch, err := NewGitHubDispatch(fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, tlsConfig, "", "", "", nil, nil)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/github_fuzz_test.go
+++ b/internal/notifier/github_fuzz_test.go
@@ -18,6 +18,7 @@ package notifier
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -48,7 +49,8 @@ func Fuzz_GitHub(f *testing.F) {
 		var cert x509.CertPool
 		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
 
-		github, err := NewGitHub(commitStatus, fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, &cert, "", "foo", "bar", nil, nil)
+		tlsConfig := &tls.Config{RootCAs: &cert}
+		github, err := NewGitHub(commitStatus, fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, tlsConfig, "", "foo", "bar", nil, nil)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/github_helpers.go
+++ b/internal/notifier/github_helpers.go
@@ -19,7 +19,6 @@ package notifier
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -67,7 +66,7 @@ func getGitHubAppOptions(providerName, providerNamespace, proxy string,
 }
 
 // getRepoInfoAndGithubClient gets the github client and repository info used by Github and GithubDispatch providers
-func getRepoInfoAndGithubClient(addr string, token string, certPool *x509.CertPool,
+func getRepoInfoAndGithubClient(addr string, token string, tlsConfig *tls.Config,
 	proxyURL string, providerName string, providerNamespace string,
 	secretData map[string][]byte, tokenCache *cache.TokenCache) (*repoInfo, error) {
 
@@ -112,11 +111,9 @@ func getRepoInfoAndGithubClient(addr string, token string, certPool *x509.CertPo
 	tc := oauth2.NewClient(context.Background(), ts)
 	client := gogithub.NewClient(tc)
 	if baseUrl.Host != "github.com" {
-		if certPool != nil {
+		if tlsConfig != nil {
 			tr := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs: certPool,
-				},
+				TLSClientConfig: tlsConfig,
 			}
 			hc := &http.Client{Transport: tr}
 			ctx := context.WithValue(context.Background(), oauth2.HTTPClient, hc)

--- a/internal/notifier/gitlab.go
+++ b/internal/notifier/gitlab.go
@@ -19,7 +19,6 @@ package notifier
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -36,7 +35,7 @@ type GitLab struct {
 	Client       *gitlab.Client
 }
 
-func NewGitLab(commitStatus string, addr string, token string, certPool *x509.CertPool) (*GitLab, error) {
+func NewGitLab(commitStatus string, addr string, token string, tlsConfig *tls.Config) (*GitLab, error) {
 	if len(token) == 0 {
 		return nil, errors.New("gitlab token cannot be empty")
 	}
@@ -52,11 +51,9 @@ func NewGitLab(commitStatus string, addr string, token string, certPool *x509.Ce
 	}
 
 	opts := []gitlab.ClientOptionFunc{gitlab.WithBaseURL(host)}
-	if certPool != nil {
+	if tlsConfig != nil {
 		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: certPool,
-			},
+			TLSClientConfig: tlsConfig,
 		}
 		hc := &http.Client{Transport: tr}
 		opts = append(opts, gitlab.WithHTTPClient(hc))

--- a/internal/notifier/gitlab_fuzz_test.go
+++ b/internal/notifier/gitlab_fuzz_test.go
@@ -18,6 +18,7 @@ package notifier
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -46,7 +47,8 @@ func Fuzz_GitLab(f *testing.F) {
 		var cert x509.CertPool
 		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
 
-		gitLab, err := NewGitLab(commitStatus, fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, &cert)
+		tlsConfig := &tls.Config{RootCAs: &cert}
+		gitLab, err := NewGitLab(commitStatus, fmt.Sprintf("%s/%s", ts.URL, urlSuffix), token, tlsConfig)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
## Summary

This PR adds mTLS support for Git-based notifiers as part of fluxcd/flux2#5433.

Replaces x509.CertPool with tls.Config across all Git-based notifiers (GitHub, GitLab, Gitea, Bitbucket, Azure DevOps, GitHub Dispatch) to enable mutual TLS authentication for enterprise environments, and adopts runtime/secrets AuthMethodsFromSecret for standardized authentication handling.

This is a follow-up to #1137 that extended the same mTLS capability to postMessage-based notifiers.