### PR TITLE
Add mTLS support for DataDog and Sentry notifiers

### DIFF
--- a/docs/spec/v1beta3/providers.md
+++ b/docs/spec/v1beta3/providers.md
@@ -1205,6 +1205,7 @@ The following providers support client certificate authentication:
 | `azuredevops`       | Azure DevOps                   |
 | `bitbucket`         | Bitbucket                      |
 | `bitbucketserver`   | BitBucket Server/Data Center   |
+| `datadog`           | DataDog                        |
 | `discord`           | Discord webhooks               |
 | `forwarder`         | Generic forwarder              |
 | `gitea`             | Gitea                          |
@@ -1217,6 +1218,7 @@ The following providers support client certificate authentication:
 | `opsgenie`          | Opsgenie alerts                |
 | `pagerduty`         | PagerDuty events               |
 | `rocket`            | Rocket.Chat                    |
+| `sentry`            | Sentry                         |
 | `slack`             | Slack API                      |
 | `webex`             | Webex messages                 |
 

--- a/internal/notifier/datadog.go
+++ b/internal/notifier/datadog.go
@@ -19,7 +19,6 @@ package notifier
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -41,7 +40,7 @@ type DataDog struct {
 // url: The DataDog API endpoint to use. Examples: https://api.datadoghq.com, https://api.datadoghq.eu, etc.
 // token: The DataDog API key (not the application key).
 // headers: A map of extra tags to add to the event
-func NewDataDog(address string, proxyUrl string, certPool *x509.CertPool, token string) (*DataDog, error) {
+func NewDataDog(address string, proxyUrl string, tlsConfig *tls.Config, token string) (*DataDog, error) {
 	conf := datadog.NewConfiguration()
 
 	if token == "" {
@@ -56,7 +55,7 @@ func NewDataDog(address string, proxyUrl string, certPool *x509.CertPool, token 
 	conf.Host = baseUrl.Host
 	conf.Scheme = baseUrl.Scheme
 
-	if proxyUrl != "" || certPool != nil {
+	if proxyUrl != "" || tlsConfig != nil {
 		transport := &http.Transport{}
 
 		if proxyUrl != "" {
@@ -68,10 +67,8 @@ func NewDataDog(address string, proxyUrl string, certPool *x509.CertPool, token 
 			transport.Proxy = http.ProxyURL(proxy)
 		}
 
-		if certPool != nil {
-			transport.TLSClientConfig = &tls.Config{
-				RootCAs: certPool,
-			}
+		if tlsConfig != nil {
+			transport.TLSClientConfig = tlsConfig
 		}
 
 		conf.HTTPClient = &http.Client{

--- a/internal/notifier/datadog_fuzz_test.go
+++ b/internal/notifier/datadog_fuzz_test.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"io"
 	"net/http"
@@ -33,7 +34,8 @@ func Fuzz_DataDog(f *testing.F) {
 		var cert x509.CertPool
 		_ = fuzz.NewConsumer(seed).GenerateStruct(&cert)
 
-		dd, err := NewDataDog(ts.URL, "", &cert, apiKey)
+		tlsConfig := &tls.Config{RootCAs: &cert}
+		dd, err := NewDataDog(ts.URL, "", tlsConfig, apiKey)
 		if err != nil {
 			return
 		}

--- a/internal/notifier/factory.go
+++ b/internal/notifier/factory.go
@@ -271,7 +271,7 @@ func webexNotifierFunc(opts notifierOptions) (Interface, error) {
 }
 
 func sentryNotifierFunc(opts notifierOptions) (Interface, error) {
-	return NewSentry(opts.CertPool, opts.URL, opts.Channel)
+	return NewSentry(opts.TLSConfig, opts.URL, opts.Channel)
 }
 
 func azureEventHubNotifierFunc(opts notifierOptions) (Interface, error) {
@@ -307,7 +307,7 @@ func pagerDutyNotifierFunc(opts notifierOptions) (Interface, error) {
 }
 
 func dataDogNotifierFunc(opts notifierOptions) (Interface, error) {
-	return NewDataDog(opts.URL, opts.ProxyURL, opts.CertPool, opts.Token)
+	return NewDataDog(opts.URL, opts.ProxyURL, opts.TLSConfig, opts.Token)
 }
 
 func natsNotifierFunc(opts notifierOptions) (Interface, error) {

--- a/internal/notifier/sentry.go
+++ b/internal/notifier/sentry.go
@@ -19,7 +19,6 @@ package notifier
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"net/http"
 
@@ -33,17 +32,15 @@ type Sentry struct {
 }
 
 // NewSentry creates a Sentry client from the provided Data Source Name (DSN)
-func NewSentry(certPool *x509.CertPool, dsn string, environment string) (*Sentry, error) {
+func NewSentry(tlsConfig *tls.Config, dsn string, environment string) (*Sentry, error) {
 	if dsn == "" {
 		return nil, fmt.Errorf("DSN cannot be empty")
 	}
 
 	tr := &http.Transport{}
-	if certPool != nil {
+	if tlsConfig != nil {
 		tr = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: certPool,
-			},
+			TLSClientConfig: tlsConfig,
 		}
 	}
 	client, err := sentry.NewClient(sentry.ClientOptions{


### PR DESCRIPTION
ref: fluxcd/flux2#5433

This completes the work for the above issue in this repository, since it targets notifiers that were already receiving a CA.