### PR TITLE
Remove deprecated proxy fields from Provider API

### DIFF
--- a/api/v1beta3/provider_types.go
+++ b/api/v1beta3/provider_types.go
@@ -98,14 +98,6 @@ type ProviderSpec struct {
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
-	// Proxy the HTTP/S address of the proxy server.
-	// Deprecated: Use ProxySecretRef instead. Will be removed in v1.
-	// +kubebuilder:validation:Pattern="^(http|https)://.*$"
-	// +kubebuilder:validation:MaxLength:=2048
-	// +kubebuilder:validation:Optional
-	// +optional
-	Proxy string `json:"proxy,omitempty"`
-
 	// ProxySecretRef specifies the Secret containing the proxy configuration
 	// for this Provider. The Secret should contain an 'address' key with the
 	// HTTP/S address of the proxy server. Optional 'username' and 'password'

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -297,13 +297,6 @@ spec:
                   Deprecated and not used in v1beta3.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
-              proxy:
-                description: |-
-                  Proxy the HTTP/S address of the proxy server.
-                  Deprecated: Use ProxySecretRef instead. Will be removed in v1.
-                maxLength: 2048
-                pattern: ^(http|https)://.*$
-                type: string
               proxySecretRef:
                 description: |-
                   ProxySecretRef specifies the Secret containing the proxy configuration

--- a/docs/api/v1beta3/notification.md
+++ b/docs/api/v1beta3/notification.md
@@ -323,19 +323,6 @@ Kubernetes meta/v1.Duration
 </tr>
 <tr>
 <td>
-<code>proxy</code><br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Proxy the HTTP/S address of the proxy server.
-Deprecated: Use ProxySecretRef instead. Will be removed in v1.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>proxySecretRef</code><br>
 <em>
 <a href="https://pkg.go.dev/github.com/fluxcd/pkg/apis/meta#LocalObjectReference">
@@ -667,19 +654,6 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>Timeout for sending alerts to the Provider.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>proxy</code><br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Proxy the HTTP/S address of the proxy server.
-Deprecated: Use ProxySecretRef instead. Will be removed in v1.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta3/providers.md
+++ b/docs/spec/v1beta3/providers.md
@@ -1253,7 +1253,6 @@ credentials for the provider API.
 The Kubernetes secret can have any of the following keys:
 
 - `address` - overrides `.spec.address`
-- `proxy` - overrides `.spec.proxy` (deprecated, use `.spec.proxySecretRef` instead. **Support for this key will be removed in v1**)
 - `token` - used for authentication
 - `username` - overrides `.spec.username`
 - `password` - used for authentication, often in combination with `username` (or `.spec.username`)
@@ -1312,7 +1311,7 @@ stringData:
 #### Proxy auth example
 
 Some networks need to use an authenticated proxy to access external services.
-The recommended approach is to use `.spec.proxySecretRef` with a dedicated Secret:
+Use `.spec.proxySecretRef` with a dedicated Secret:
 
 ```yaml
 ---
@@ -1325,20 +1324,6 @@ stringData:
   address: "http://proxy_url:proxy_port"
   username: "proxy_username"
   password: "proxy_password"
-```
-
-**Legacy approach (deprecated):**
-The proxy address can also be stored in the main secret to hide parameters like the username and password:
-
-```yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: my-provider-proxy-legacy
-  namespace: default
-stringData:
-  proxy: "http://username:password@proxy_url:proxy_port"
 ```
 
 ### Certificate secret reference
@@ -1466,18 +1451,10 @@ the controller will log a deprecation warning.
 
 ### HTTP/S proxy
 
-`.spec.proxy` is an optional field to specify an HTTP/S proxy address.
-**Warning:** This field is deprecated, use `.spec.proxySecretRef` instead. **Support for this field will be removed in v1.**
-
 `.spec.proxySecretRef` is an optional field to specify a name reference to a
 Secret in the same namespace as the Provider, containing the proxy configuration.
 The Secret should contain an `address` key with the HTTP/S address of the proxy server.
 Optional `username` and `password` keys can be provided for proxy authentication.
-
-If the proxy address contains sensitive information such as basic auth credentials, it is
-recommended to use `.spec.proxySecretRef` instead of `.spec.proxy`.
-When `.spec.proxySecretRef` is specified, both `.spec.proxy` and the `proxy` key from
-`.spec.secretRef` are ignored.
 
 ### Timeout
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fluxcd/pkg/cache v0.12.0
 	github.com/fluxcd/pkg/git v0.38.0
 	github.com/fluxcd/pkg/masktoken v0.8.0
-	github.com/fluxcd/pkg/runtime v0.91.0
+	github.com/fluxcd/pkg/runtime v0.92.0
 	github.com/fluxcd/pkg/ssa v0.61.0
 	github.com/fluxcd/pkg/ssh v0.23.0
 	github.com/getsentry/sentry-go v0.35.3

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/fluxcd/pkg/git v0.38.0 h1:fFH2PkL+VCtQ1aJec/6l3Wq5fQG1w02HHKfVY+gz1S4
 github.com/fluxcd/pkg/git v0.38.0/go.mod h1:PHilCGIM2t10CJ++yK4SFHIcBAXqMk14XcwZ/Rqw23I=
 github.com/fluxcd/pkg/masktoken v0.8.0 h1:Dm5xIVNbg0s6zNttjDvimaG38bKsXwxBVo5b+D7ThVU=
 github.com/fluxcd/pkg/masktoken v0.8.0/go.mod h1:Gc73ALOqIe+5Gj2V3JggMNiYcBiZ9bNNDYBE9R5XTTg=
-github.com/fluxcd/pkg/runtime v0.91.0 h1:Z92sOLsJXa+0RIi/vNl87zF5qnsBUdOb60d2a0b4Ulo=
-github.com/fluxcd/pkg/runtime v0.91.0/go.mod h1:D/gUsaSpyw6Od2QEL7MELi5m+oUmwokuxUVZ+vKQxdo=
+github.com/fluxcd/pkg/runtime v0.92.0 h1:FqelIv8L8TPCNnuF4cc7c/43P2p6aDT7FRDuZY6/kB8=
+github.com/fluxcd/pkg/runtime v0.92.0/go.mod h1:D/gUsaSpyw6Od2QEL7MELi5m+oUmwokuxUVZ+vKQxdo=
 github.com/fluxcd/pkg/ssa v0.61.0 h1:GeueQfZVrjPLEzmEkq6gpFTBr1MDcqUihCQDf6AaIo8=
 github.com/fluxcd/pkg/ssa v0.61.0/go.mod h1:PNRlgihYbmlQU5gzsB14nrsNMbtACNanBnKhLCWmeX8=
 github.com/fluxcd/pkg/ssh v0.23.0 h1:PqmBpQB7Rxspdb3LZZo2yflC7m990EU/cYtjK3sO3Tg=

--- a/internal/server/event_handlers_test.go
+++ b/internal/server/event_handlers_test.go
@@ -600,7 +600,6 @@ func TestCreateNotifier(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		// TODO: Remove deprecated secret proxy key tests when Provider v1 is released.
 		{
 			name: "reference to secret with valid address, proxy, headers",
 			providerSpec: &apiv1beta3.ProviderSpec{
@@ -611,17 +610,6 @@ func TestCreateNotifier(t *testing.T) {
 				"address": []byte("https://example.com"),
 				"proxy":   []byte("https://exampleproxy.com"),
 				"headers": []byte(`foo: bar`),
-			},
-		},
-		{
-			name: "reference to secret with invalid proxy",
-			providerSpec: &apiv1beta3.ProviderSpec{
-				Type:      "slack",
-				SecretRef: &meta.LocalObjectReference{Name: secretName},
-			},
-			secretData: map[string][]byte{
-				"address": []byte("https://example.com"),
-				"proxy":   []byte("https://exampleproxy.com|"),
 			},
 			wantErr: true,
 		},
@@ -646,19 +634,6 @@ func TestCreateNotifier(t *testing.T) {
 			},
 			secretData: map[string][]byte{
 				"address": []byte("https://example.com"),
-			},
-		},
-		// TODO: Remove deprecated spec.proxy field tests when Provider v1 is released.
-		{
-			name: "invalid spec proxy overridden by valid secret ref proxy",
-			providerSpec: &apiv1beta3.ProviderSpec{
-				Type:      "slack",
-				SecretRef: &meta.LocalObjectReference{Name: secretName},
-				Proxy:     "https://example.com|",
-			},
-			secretData: map[string][]byte{
-				"address": []byte("https://example.com"),
-				"proxy":   []byte("https://example.com"),
 			},
 		},
 		{
@@ -869,15 +844,6 @@ Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
 				"username": []byte("proxyuser"),
 			},
 			wantErr: true,
-		},
-		// TODO: Remove deprecated spec.proxy field tests when Provider v1 is released.
-		{
-			name: "deprecated spec.proxy field",
-			providerSpec: &apiv1beta3.ProviderSpec{
-				Type:    "generic",
-				Address: "https://example.com",
-				Proxy:   "http://proxy.example.com:8080",
-			},
 		},
 		{
 			name: "provider type that does not require address field",


### PR DESCRIPTION
ref: #1144 .

Note: The proxy URL parsing optimization mentioned in #1144 will be addressed in a separate follow-up PR.