### PR TITLE
Allow using Bitbucket Cloud API Token for authorization

### DIFF
--- a/internal/notifier/bitbucket_fuzz_test.go
+++ b/internal/notifier/bitbucket_fuzz_test.go
@@ -33,7 +33,11 @@ import (
 
 func Fuzz_Bitbucket(f *testing.F) {
 	f.Add("kustomization/gitops-system/0c9c2e41", "user:pass", "org/repo", "revision/dsa123a", "info", []byte{}, []byte(`{"state":"SUCCESSFUL","description":"","key":"","name":"","url":""}`))
+	f.Add("kustomization/gitops-system/0c9c2e41", "x-token-auth:pass", "org/repo", "revision/dsa123a", "info", []byte{}, []byte(`{"state":"SUCCESSFUL","description":"","key":"","name":"","url":""}`))
+	f.Add("kustomization/gitops-system/0c9c2e41", "x-bitbucket-api-token-auth:pass", "org/repo", "revision/dsa123a", "info", []byte{}, []byte(`{"state":"SUCCESSFUL","description":"","key":"","name":"","url":""}`))
 	f.Add("kustomization/gitops-system/0c9c2e41", "user:pass", "org/repo", "revision/dsa123a", "error", []byte{}, []byte(`{}`))
+	f.Add("kustomization/gitops-system/0c9c2e41", "x-token-auth:pass", "org/repo", "revision/dsa123a", "error", []byte{}, []byte(`{}`))
+	f.Add("kustomization/gitops-system/0c9c2e41", "x-bitbucket-api-token-auth", "org/repo", "revision/dsa123a", "error", []byte{}, []byte(`{}`))
 
 	f.Fuzz(func(t *testing.T, commitStatus, token, urlSuffix, revision, severity string, seed, response []byte) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/notifier/bitbucket_test.go
+++ b/internal/notifier/bitbucket_test.go
@@ -22,9 +22,27 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestNewBitbucketBasic(t *testing.T) {
+func TestNewBitbucketBasicAuth(t *testing.T) {
 	g := NewWithT(t)
 	b, err := NewBitbucket("kustomization/gitops-system/0c9c2e41", "https://bitbucket.org/foo/bar", "foo:bar", nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(b.Owner).To(Equal("foo"))
+	g.Expect(b.Repo).To(Equal("bar"))
+	g.Expect(b.CommitStatus).To(Equal("kustomization/gitops-system/0c9c2e41"))
+}
+
+func TestNewBitbucketOAuthRepositoryToken(t *testing.T) {
+	g := NewWithT(t)
+	b, err := NewBitbucket("kustomization/gitops-system/0c9c2e41", "https://bitbucket.org/foo/bar", "x-token-auth:bar", nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(b.Owner).To(Equal("foo"))
+	g.Expect(b.Repo).To(Equal("bar"))
+	g.Expect(b.CommitStatus).To(Equal("kustomization/gitops-system/0c9c2e41"))
+}
+
+func TestNewBitbucketOAuthPersonalToken(t *testing.T) {
+	g := NewWithT(t)
+	b, err := NewBitbucket("kustomization/gitops-system/0c9c2e41", "https://bitbucket.org/foo/bar", "x-bitbucket-api-token-auth:bar", nil)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(b.Owner).To(Equal("foo"))
 	g.Expect(b.Repo).To(Equal("bar"))


### PR DESCRIPTION
Bitbucket deprecated app paswords and tells users to use API tokens instead. But API tokens (for example repo api tokens) they don't work with username:password scheme where username is the bot email. This pull request changes auth to NewOAuthbearerToken if the username is `x-api-token-auth` or `x-bitbucket-api-token-auth` as Bitbucket tells in the documentation.
https://developer.atlassian.com/cloud/bitbucket/rest/intro/#app-passwords

Before the change I was always getting the 401 error (tried various combinations of email, username, personal tokens and repo tokens)
<img width="1881" height="162" alt="image" src="https://github.com/user-attachments/assets/976a2247-d3e4-45d8-bae0-ad2ed62b913d" />

After a change it works
<img width="337" height="203" alt="image" src="https://github.com/user-attachments/assets/e92e1a17-3241-4216-a993-76a6e53b53eb" />
