### PR TITLE
Support commit status for any Flux APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,13 +17,13 @@ require (
 	github.com/elazarl/goproxy v1.8.0
 	github.com/fluxcd/cli-utils v0.37.1-flux.1
 	github.com/fluxcd/notification-controller/api v1.7.0
-	github.com/fluxcd/pkg/apis/event v0.23.0
+	github.com/fluxcd/pkg/apis/event v0.24.0
 	github.com/fluxcd/pkg/apis/meta v1.25.0
 	github.com/fluxcd/pkg/auth v0.36.0
 	github.com/fluxcd/pkg/cache v0.13.0
 	github.com/fluxcd/pkg/git v0.42.0
 	github.com/fluxcd/pkg/masktoken v0.8.0
-	github.com/fluxcd/pkg/runtime v0.98.0
+	github.com/fluxcd/pkg/runtime v0.99.0
 	github.com/fluxcd/pkg/ssa v0.66.0
 	github.com/fluxcd/pkg/ssh v0.24.0
 	github.com/getsentry/sentry-go v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/fluxcd/cli-utils v0.37.1-flux.1 h1:WnG2mHxCPZMj/soIq/S/1zvbrGCJN3GJGb
 github.com/fluxcd/cli-utils v0.37.1-flux.1/go.mod h1:aND5wX3LuTFtB7eUT7vsWr8mmxRVSPR2Wkvbn0SqPfw=
 github.com/fluxcd/pkg/apis/acl v0.9.0 h1:wBpgsKT+jcyZEcM//OmZr9RiF8klL3ebrDp2u2ThsnA=
 github.com/fluxcd/pkg/apis/acl v0.9.0/go.mod h1:TttNS+gocsGLwnvmgVi3/Yscwqrjc17+vhgYfqkfrV4=
-github.com/fluxcd/pkg/apis/event v0.23.0 h1:4FsDb/bmukqA2TI6iYI0j4JSH3B+sVTXXsDngrAAgFA=
-github.com/fluxcd/pkg/apis/event v0.23.0/go.mod h1:Hoi4DejaNKVahGkRXqGBjT9h1aKmhc7RCYcsgoTieqc=
+github.com/fluxcd/pkg/apis/event v0.24.0 h1:WVPf0FrJ5JExRDDGoo4W0jZgHZt0n4E48/e8b3TSmkA=
+github.com/fluxcd/pkg/apis/event v0.24.0/go.mod h1:Hoi4DejaNKVahGkRXqGBjT9h1aKmhc7RCYcsgoTieqc=
 github.com/fluxcd/pkg/apis/kustomize v1.15.0 h1:p8wPIxdmn0vy0a664rsE9JKCfnliZz4HUsDcTy4ZOxA=
 github.com/fluxcd/pkg/apis/kustomize v1.15.0/go.mod h1:XWdsx8P15OiMaQIvmUjYWdmD3zAwhl5q9osl5iCqcOk=
 github.com/fluxcd/pkg/apis/meta v1.25.0 h1:fmZgMoe7yITGfhFqdOs7w2GOu3Y/2Vvz4+4p/eay3eA=
@@ -151,8 +151,8 @@ github.com/fluxcd/pkg/git v0.42.0 h1:ahX9sSaOTd9Fb2I8E61UZx0kSMuP44oxXORSmEzkk8U
 github.com/fluxcd/pkg/git v0.42.0/go.mod h1:iqR4eZEhd3gdRSkv+VDP3Qz9WCner3aZ5ClkOUe+3fc=
 github.com/fluxcd/pkg/masktoken v0.8.0 h1:Dm5xIVNbg0s6zNttjDvimaG38bKsXwxBVo5b+D7ThVU=
 github.com/fluxcd/pkg/masktoken v0.8.0/go.mod h1:Gc73ALOqIe+5Gj2V3JggMNiYcBiZ9bNNDYBE9R5XTTg=
-github.com/fluxcd/pkg/runtime v0.98.0 h1:FZB+PUYtvXDrfJRBDcTKdwEHGFarOg5nuDdCUdbb34s=
-github.com/fluxcd/pkg/runtime v0.98.0/go.mod h1:L57AzkqndkbnOFgIYStbuwSDPqIBUa+KeevLZ8czl+k=
+github.com/fluxcd/pkg/runtime v0.99.0 h1:7UKcpXwdahCtmOxexKJK2BUTzcTLZlemmB5FdQAAJTM=
+github.com/fluxcd/pkg/runtime v0.99.0/go.mod h1:MlqGtL3CkfXeTP6Ih5p0R/GdFOWmrxZo3fPpaXYsxN8=
 github.com/fluxcd/pkg/ssa v0.66.0 h1:CYbCTuws8Sn1xAaOFNz92yS2iS5YBqJgd+DrzmRxfaQ=
 github.com/fluxcd/pkg/ssa v0.66.0/go.mod h1:RjvVjJIoRo1ecsv91yMuiqzO6cpNag80M6MOB/vrJdc=
 github.com/fluxcd/pkg/ssh v0.24.0 h1:hrPlxs0hhXf32DRqs68VbsXs0XfQMphyRVIk0rYYJa4=

--- a/internal/server/provider_change_request.go
+++ b/internal/server/provider_change_request.go
@@ -22,9 +22,9 @@ import (
 	apiv1beta3 "github.com/fluxcd/notification-controller/api/v1beta3"
 )
 
-// isChangeRequestCommentProvider returns true if the provider type is a
-// change request comment provider.
-func isChangeRequestCommentProvider(providerType string) bool {
+// isChangeRequestProvider returns true if the provider type is a
+// change request provider.
+func isChangeRequestProvider(providerType string) bool {
 	return providerType == apiv1beta3.GitHubPullRequestCommentProvider ||
 		providerType == apiv1beta3.GitLabMergeRequestCommentProvider
 }

--- a/internal/server/provider_commit_status.go
+++ b/internal/server/provider_commit_status.go
@@ -108,3 +108,8 @@ func isCommitStatusUpdate(event *eventv1.Event) bool {
 	key := event.InvolvedObject.GetObjectKind().GroupVersionKind().Group + "/" + eventv1.MetaCommitStatusKey
 	return event.Metadata[key] == eventv1.MetaCommitStatusUpdateValue
 }
+
+// hasCommitKey returns true if the event has the commit metadata key.
+func hasCommitKey(event *eventv1.Event) bool {
+	return event.Metadata[eventv1.Group+"/"+eventv1.MetaCommitKey] != ""
+}


### PR DESCRIPTION
Depends on: https://github.com/fluxcd/pkg/pull/1087

Events containing the `commit` metadata key prefixed by the RFC-0008 API Group (`event.toolkit.fluxcd.io`) will now make it to Git commit status.

In the screenshot below, the commit status in the middle is the result of this PR.

<img width="662" height="228" alt="Screenshot from 2026-02-06 17-42-29" src="https://github.com/user-attachments/assets/b5ebd1f2-6ea0-472c-b0f7-20a3bfeffd26" />
