### PR TITLE
Remove no longer needed workaround for Flux 2.8

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -7,6 +7,6 @@ jobs:
     permissions:
       contents: write # for reading and creating branches.
       pull-requests: write # for creating pull requests against release branches.
-    uses: fluxcd/gha-workflows/.github/workflows/backport.yaml@v0.8.0
+    uses: fluxcd/gha-workflows/.github/workflows/backport.yaml@v0.9.0
     secrets:
       github-token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -9,7 +9,7 @@ jobs:
       contents: read # for reading the repository code.
     steps:
       - name: Test suite setup
-        uses: fluxcd/gha-workflows/.github/actions/setup-kubernetes@v0.8.0
+        uses: fluxcd/gha-workflows/.github/actions/setup-kubernetes@v0.9.0
         with:
           go-version: 1.26.x
       - name: Smoke test Fuzzers

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,7 @@ jobs:
       contents: read # for reading the repository code.
     steps:
       - name: Test suite setup
-        uses: fluxcd/gha-workflows/.github/actions/setup-kubernetes@v0.8.0
+        uses: fluxcd/gha-workflows/.github/actions/setup-kubernetes@v0.9.0
         with:
           go-version: 1.26.x
       - name: Run tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: write # for creating the GitHub release.
       id-token: write # for creating OIDC tokens for signing.
       packages: write # for pushing and signing container images.
-    uses: fluxcd/gha-workflows/.github/workflows/controller-release.yaml@v0.8.0
+    uses: fluxcd/gha-workflows/.github/workflows/controller-release.yaml@v0.9.0
     with:
       controller: ${{ github.event.repository.name }}
       release-candidate-prefix: ${{ github.event.inputs.tag }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read # for reading the repository code.
       security-events: write # for uploading the CodeQL analysis results.
-    uses: fluxcd/gha-workflows/.github/workflows/code-scan.yaml@v0.8.0
+    uses: fluxcd/gha-workflows/.github/workflows/code-scan.yaml@v0.9.0
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       fossa-token: ${{ secrets.FOSSA_TOKEN }}

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: read # for reading the labels file.
       issues: write # for creating and updating labels.
-    uses: fluxcd/gha-workflows/.github/workflows/labels-sync.yaml@v0.8.0
+    uses: fluxcd/gha-workflows/.github/workflows/labels-sync.yaml@v0.9.0
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upgrade-fluxcd-pkg.yaml
+++ b/.github/workflows/upgrade-fluxcd-pkg.yaml
@@ -2,20 +2,9 @@ name: upgrade-fluxcd-pkg
 
 on:
   workflow_dispatch:
-    inputs:
-      pre-release-pkg:
-        description: >-
-          Temporary flag for Flux 2.8: use the flux/v2.8.x pkg branch for main branches
-          because the pkg release branch was cut before the Flux distribution release.
-          Remove this input once Flux 2.8.0 is released.
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   upgrade-fluxcd-pkg:
-    uses: fluxcd/gha-workflows/.github/workflows/upgrade-fluxcd-pkg.yaml@v0.8.0
-    with:
-      pre-release-pkg: ${{ inputs.pre-release-pkg }}
+    uses: fluxcd/gha-workflows/.github/workflows/upgrade-fluxcd-pkg.yaml@v0.9.0
     secrets:
       github-token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Upgrade `upgrade-fluxcd-pkg` workflow to `fluxcd/gha-workflows@v0.9.0` and remove the
temporary `pre-release-pkg` workaround that is no longer needed now that Flux 2.8.0 has
been released.