### PR TITLE
Fix commit status providers requiring only commit event key

### DIFF
--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -322,8 +322,9 @@ func (s *EventServer) getNotificationParams(ctx context.Context, event *eventv1.
 		return nil, droppedProviders{}, nil
 	}
 
-	// Skip if the provider is a commit status provider but the event doesn't have the commit metadata key.
-	if isCommitStatusProvider(provider.Spec.Type) && !hasCommitKey(event) {
+	// Skip if the provider is a commit status provider but the event doesn't have the commit metadata key
+	// and the event is not a commit status update.
+	if isCommitStatusProvider(provider.Spec.Type) && !hasCommitKey(event) && !isCommitStatusUpdate(event) {
 		// Return true on dropped event for a commit status provider
 		// when the event doesn't have the commit metadata key.
 		return nil, droppedProviders{commitStatus: true}, nil


### PR DESCRIPTION
Fixes: #1246
Fixes: https://github.com/fluxcd/flux2/issues/5737

Tests added. They fail without the fix.