### PR TITLE
Wrap error in Sentry provider client initialization

### DIFF
--- a/internal/notifier/sentry.go
+++ b/internal/notifier/sentry.go
@@ -50,7 +50,7 @@ func NewSentry(tlsConfig *tls.Config, dsn string, environment string) (*Sentry, 
 		TracesSampleRate: 1,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create Sentry client: %w", err)
 	}
 
 	return &Sentry{


### PR DESCRIPTION
Wrap the error from `sentry.NewClient` with context, matching the pattern used by other providers.