### PR TITLE
Add FeatureFlag CacheFluxcdObjects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,10 @@ require (
 	github.com/chainguard-dev/git-urls v1.0.2
 	github.com/elazarl/goproxy v1.8.1
 	github.com/fluxcd/cli-utils v0.37.1-flux.1
+	github.com/fluxcd/helm-controller/api v1.5.1
+	github.com/fluxcd/image-automation-controller/api v1.1.0
+	github.com/fluxcd/image-reflector-controller/api v1.1.0
+	github.com/fluxcd/kustomize-controller/api v1.8.1
 	github.com/fluxcd/notification-controller/api v1.8.0
 	github.com/fluxcd/pkg/apis/event v0.24.0
 	github.com/fluxcd/pkg/apis/meta v1.25.0
@@ -26,6 +30,7 @@ require (
 	github.com/fluxcd/pkg/runtime v0.100.1
 	github.com/fluxcd/pkg/ssa v0.67.1
 	github.com/fluxcd/pkg/ssh v0.24.0
+	github.com/fluxcd/source-controller/api v1.8.0
 	github.com/getsentry/sentry-go v0.42.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/cel-go v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,14 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fluxcd/cli-utils v0.37.1-flux.1 h1:WnG2mHxCPZMj/soIq/S/1zvbrGCJN3GJGbNfG06X55M=
 github.com/fluxcd/cli-utils v0.37.1-flux.1/go.mod h1:aND5wX3LuTFtB7eUT7vsWr8mmxRVSPR2Wkvbn0SqPfw=
+github.com/fluxcd/helm-controller/api v1.5.1 h1:yraWl0ImzO4yIy/N5d9i54N+OZxKuFZqjed8wrIjy8U=
+github.com/fluxcd/helm-controller/api v1.5.1/go.mod h1:Yr0y7GKizbvQQGK5wBX6sGCZrTY86AN9n1PNEsji2XE=
+github.com/fluxcd/image-automation-controller/api v1.1.0 h1:CLPNHQskX0falo4s1suG1ztUe9IGaY9q5ntcz5Fxt9A=
+github.com/fluxcd/image-automation-controller/api v1.1.0/go.mod h1:dIpTDlWgUfjvdGZCNfe8Ht9sCiHwRbJDoIbwfLQ56wc=
+github.com/fluxcd/image-reflector-controller/api v1.1.0 h1:7TtE9DrCnlH1Wn3R3UKXJHNhX/FgS0ejdjFKHzl+XHs=
+github.com/fluxcd/image-reflector-controller/api v1.1.0/go.mod h1:hLGsqTv3RydJXaApmN+ZtIOHNxlUdmuOJl323x6dsPE=
+github.com/fluxcd/kustomize-controller/api v1.8.1 h1:Pe5+sV1i1EwfK5TA4ogYX6YJ6ADJaETmG58WYieRkG4=
+github.com/fluxcd/kustomize-controller/api v1.8.1/go.mod h1:+ZJB/dIGbnSzZ5J/kiJ8n0USmLNAjfeZU6Xfra0oMZA=
 github.com/fluxcd/pkg/apis/acl v0.9.0 h1:wBpgsKT+jcyZEcM//OmZr9RiF8klL3ebrDp2u2ThsnA=
 github.com/fluxcd/pkg/apis/acl v0.9.0/go.mod h1:TttNS+gocsGLwnvmgVi3/Yscwqrjc17+vhgYfqkfrV4=
 github.com/fluxcd/pkg/apis/event v0.24.0 h1:WVPf0FrJ5JExRDDGoo4W0jZgHZt0n4E48/e8b3TSmkA=
@@ -157,6 +165,8 @@ github.com/fluxcd/pkg/ssa v0.67.1 h1:wmwrznP+USRUtppKRjAiBx3ayriygRx0IeMdX7z/HaM
 github.com/fluxcd/pkg/ssa v0.67.1/go.mod h1:PFXVjChubQOiWDxalpwh6PzRsEswGqnKwZB4ScoxDx4=
 github.com/fluxcd/pkg/ssh v0.24.0 h1:hrPlxs0hhXf32DRqs68VbsXs0XfQMphyRVIk0rYYJa4=
 github.com/fluxcd/pkg/ssh v0.24.0/go.mod h1:xWammEqalrpurpcMiixJRXtynRQtBEoqheyU5F/vWrg=
+github.com/fluxcd/source-controller/api v1.8.0 h1:ndrYmcv6ZMcdQHFSUkOrFVDO7h16SfDBSw/DOqf/LPo=
+github.com/fluxcd/source-controller/api v1.8.0/go.mod h1:1O7+sMbqc1+3tPvjmtgFz+bASTl794Y9SxpebHDDSGA=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -31,6 +31,12 @@ const (
 	// When enabled, it will cache both object types, resulting in increased
 	// memory usage and cluster-wide RBAC permissions (list and watch).
 	CacheSecretsAndConfigMaps = "CacheSecretsAndConfigMaps"
+	// CacheFluxObjects controls whether FluxCD objects referenced by Alerts
+	// should be cached via informers.
+	//
+	// When enabled, it will cache all Flux objects under Alerts, resulting in
+	// increased memory usage and additional RBAC permissions (list and watch).
+	CacheFluxObjects = "CacheFluxObjects"
 )
 
 var features = map[string]bool{
@@ -40,6 +46,9 @@ var features = map[string]bool{
 	// DisableConfigWatchers
 	// opt-in from v1.7.5
 	controller.FeatureGateDisableConfigWatchers: false,
+	// CacheFluxObjects
+	// opt-in from v1.9.0
+	CacheFluxObjects: false,
 }
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -50,6 +50,14 @@ import (
 	"github.com/fluxcd/pkg/runtime/pprof"
 	"github.com/fluxcd/pkg/runtime/probes"
 
+	// FluxCD controller APIs - only used when CacheFluxObjects is enabled
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	imageautov1 "github.com/fluxcd/image-automation-controller/api/v1beta2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
+
 	apiv1 "github.com/fluxcd/notification-controller/api/v1"
 	apiv1b2 "github.com/fluxcd/notification-controller/api/v1beta2"
 	apiv1b3 "github.com/fluxcd/notification-controller/api/v1beta3"
@@ -161,6 +169,19 @@ func main() {
 	}
 	if !shouldCache {
 		disableCacheFor = append(disableCacheFor, &corev1.Secret{}, &corev1.ConfigMap{})
+	}
+
+	cacheFluxObjects, err := features.Enabled(features.CacheFluxObjects)
+	if err != nil {
+		setupLog.Error(err, "unable to check feature gate "+features.CacheFluxObjects)
+		os.Exit(1)
+	}
+	if cacheFluxObjects {
+		if err := registerFluxSchemes(scheme); err != nil {
+			setupLog.Error(err, "unable to register Flux controller schemes")
+			os.Exit(1)
+		}
+		setupLog.Info("FluxCD object caching enabled via informers")
 	}
 
 	restConfig := client.GetConfigOrDie(clientOptions)
@@ -300,4 +321,24 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+// registerFluxSchemes registers FluxCD controller schemes for caching
+func registerFluxSchemes(scheme *runtime.Scheme) error {
+	if err := sourcev1.AddToScheme(scheme); err != nil {
+		return err
+	}
+	if err := sourcev1beta2.AddToScheme(scheme); err != nil {
+		return err
+	}
+	if err := kustomizev1.AddToScheme(scheme); err != nil {
+		return err
+	}
+	if err := helmv2.AddToScheme(scheme); err != nil {
+		return err
+	}
+	if err := imagev1.AddToScheme(scheme); err != nil {
+		return err
+	}
+	return imageautov1.AddToScheme(scheme)
 }


### PR DESCRIPTION
Introduce an opt-in CacheFluxObjects feature flag that enables caching of FluxCD objects (GitRepository, Kustomization, HelmRelease, etc.) via Kubernetes informers. Currently, the notification-controller makes direct API calls to fetch FluxCD objects when matching Alert event sources with label selectors. In clusters with many Alerts and FluxCD resources, this creates performance bottlenecks and increases API server load. By enabling this feature flag, FluxCD objects are cached in memory through informers, making reads significantly faster and reducing API server pressure. The implementation conditionally registers FluxCD controller schemes before manager creation, allowing controller-runtime to automatically create informers for these types. When disabled (default), the current behavior is maintained with no additional memory or RBAC requirements. When enabled, users gain improved performance at the cost of increased memory usage and additional RBAC permissions (list/watch on FluxCD resources). Enable with `--feature-gates=CacheFluxObjects=true`.