### PR TITLE
fix(security): bump github.com/cloudflare/circl to v1.6.3 (CVE-2026-1229 Critical CVSS 9.8)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudevents/sdk-go/v2 v2.15.2 // indirect
-	github.com/cloudflare/circl v1.6.1 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect - bumped from v1.6.1 to fix CVE-2026-1229 (Critical, CVSS 9.8)
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect


### PR DESCRIPTION
## Security Fix: CVE-2026-1229 (Critical, CVSS 9.8)

### Summary

This PR bumps `github.com/cloudflare/circl` from `v1.6.1` → `v1.6.3` to remediate a **Critical** severity vulnerability detected by Sysdig Secure in the production container image `ghcr.io/fluxcd/notification-controller:v1.5.0`.

### Vulnerability Details

| Field | Value |
|-------|-------|
| **CVE** | [CVE-2026-1229](https://nvd.nist.gov/vuln/detail/CVE-2026-1229) |
| **Severity** | 🔴 Critical |
| **CVSS Score** | 9.8 (AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H) |
| **Package** | `github.com/cloudflare/circl` |
| **Affected versions** | `< v1.6.3` |
| **Fixed in** | `v1.6.3` (released 2026-01-22) |
| **In-use** | ✅ Yes — actively loaded in production workloads |
| **Has exploit** | ❌ No known public exploit at this time |

### Impact

The vulnerability is remotely exploitable with no authentication required (network-accessible, low complexity). It can lead to full confidentiality, integrity, and availability compromise.

The package `github.com/cloudflare/circl` is loaded at path `/usr/local/bin/notification-controller` and confirmed **in-use** in production.

### Change

```diff
- github.com/cloudflare/circl v1.6.1 // indirect
+ github.com/cloudflare/circl v1.6.3 // indirect - bumped to fix CVE-2026-1229 (Critical, CVSS 9.8)
```

> ⚠️ **Note:** `go.sum` should be regenerated by running `go mod tidy` locally after merging, or the CI pipeline will handle it. A follow-up `go.sum` update may be required if the CI does not auto-regenerate it.

### Detected by

This vulnerability was identified by **[Sysdig Secure](https://sysdig.com/products/secure/)** zero-day monitoring on the production image `ghcr.io/fluxcd/notification-controller:v1.5.0` running in Kubernetes.

### References
- https://nvd.nist.gov/vuln/detail/CVE-2026-1229
- https://github.com/cloudflare/circl/releases/tag/v1.6.3
