### PR TITLE
Migrate to new Kubernetes events API

### DIFF
--- a/docs/spec/v1beta3/events.md
+++ b/docs/spec/v1beta3/events.md
@@ -20,14 +20,21 @@ The following is an example of an event sent by kustomize-controller to report a
     "namespace": "apps",
     "uid": "7d0cdc51-ddcf-4743-b223-83ca5c699632"
   },
+  "relatedObject": {
+    "apiVersion": "source.toolkit.fluxcd.io/v1",
+    "kind": "GitRepository",
+    "name": "webapp",
+    "namespace": "apps"
+  },
   "metadata": {
     "kustomize.toolkit.fluxcd.io/revision": "main/731f7eaddfb6af01cb2173e18f0f75b0ba780ef1"
   },
-  "severity":"error",
+  "severity": "error",
   "reason": "ValidationFailed",
-  "message":"service/apps/webapp validation error: spec.type: Unsupported value: Ingress",
-  "reportingController":"kustomize-controller",
-  "timestamp":"2022-10-28T07:26:19Z"
+  "action": "Reconciling",
+  "message": "service/apps/webapp validation error: spec.type: Unsupported value: Ingress",
+  "reportingController": "kustomize-controller",
+  "timestamp": "2022-10-28T07:26:19Z"
 }
 ```
 
@@ -35,6 +42,7 @@ In the above example:
 
 - An event is issued by kustomize-controller for a specific object, indicated in the
   `involvedObject` field.
+- `relatedObject` field optionally references a secondary object involved in the action (correlates to the source).
 - The notification-controller receives the event and finds the [alerts](alerts.md)
   that match the `involvedObject` and `severity` values.
 - For all matching alerts, the controller posts the `message` and the source revision
@@ -43,7 +51,7 @@ In the above example:
 ## Event structure
 
 The Go type that defines the event structure can be found in the
-[fluxcd/pkg/apis/event/v1beta1](https://github.com/fluxcd/pkg/blob/main/apis/event/v1beta1/event.go)
+[fluxcd/pkg/apis/event/v1](https://github.com/fluxcd/pkg/blob/main/apis/event/v1/event.go)
 package.
 
 ## Rate limiting

--- a/internal/controller/alert_controller.go
+++ b/internal/controller/alert_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,6 +27,8 @@ import (
 
 	apiv1 "github.com/fluxcd/notification-controller/api/v1"
 	apiv1beta3 "github.com/fluxcd/notification-controller/api/v1beta3"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
+	"github.com/fluxcd/pkg/runtime/events"
 	"github.com/fluxcd/pkg/runtime/patch"
 )
 
@@ -37,7 +38,7 @@ import (
 // AlertReconciler reconciles an Alert object to migrate it to static Alert.
 type AlertReconciler struct {
 	client.Client
-	kuberecorder.EventRecorder
+	events.EventRecorder
 
 	ControllerName string
 }
@@ -88,7 +89,7 @@ func (r *AlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 	controllerutil.RemoveFinalizer(obj, apiv1.NotificationFinalizer)
 
 	log.Info("removed finalizer from Alert to migrate to static Alert")
-	r.Event(obj, corev1.EventTypeNormal, "Migration", "removed finalizer from Alert to migrate to static Alert")
+	r.Eventf(obj, nil, corev1.EventTypeNormal, "Migration", eventv1.ActionReconciled, "%s", "removed finalizer from Alert to migrate to static Alert")
 
 	return
 }

--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 
-	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,6 +27,7 @@ import (
 	apiv1 "github.com/fluxcd/notification-controller/api/v1"
 	apiv1beta3 "github.com/fluxcd/notification-controller/api/v1beta3"
 	"github.com/fluxcd/pkg/cache"
+	"github.com/fluxcd/pkg/runtime/events"
 	"github.com/fluxcd/pkg/runtime/patch"
 
 	"github.com/fluxcd/notification-controller/internal/notifier"
@@ -42,7 +42,7 @@ import (
 // Provider.
 type ProviderReconciler struct {
 	client.Client
-	kuberecorder.EventRecorder
+	events.EventRecorder
 
 	TokenCache *cache.TokenCache
 }

--- a/internal/controller/receiver_controller.go
+++ b/internal/controller/receiver_controller.go
@@ -26,7 +26,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	kuberecorder "k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -37,9 +36,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"
 	helper "github.com/fluxcd/pkg/runtime/controller"
+	"github.com/fluxcd/pkg/runtime/events"
 	"github.com/fluxcd/pkg/runtime/patch"
 	"github.com/fluxcd/pkg/runtime/predicates"
 
@@ -51,7 +52,7 @@ import (
 type ReceiverReconciler struct {
 	client.Client
 	helper.Metrics
-	kuberecorder.EventRecorder
+	events.EventRecorder
 
 	ControllerName string
 }
@@ -170,14 +171,14 @@ func (r *ReceiverReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 
 		// Emit warning event if the reconciliation failed.
 		if retErr != nil {
-			r.Event(obj, corev1.EventTypeWarning, meta.FailedReason, retErr.Error())
+			r.Eventf(obj, nil, corev1.EventTypeWarning, meta.FailedReason, eventv1.ActionReconciling, "%s", retErr.Error())
 		}
 
 		// Log and emit success event.
 		if retErr == nil && conditions.IsReady(obj) {
 			msg := fmt.Sprintf("Reconciliation finished, next run in %s", obj.GetInterval().String())
 			log.Info(msg)
-			r.Event(obj, corev1.EventTypeNormal, meta.SucceededReason, msg)
+			r.Eventf(obj, nil, corev1.EventTypeNormal, meta.SucceededReason, eventv1.ActionReconciled, "%s", msg)
 		}
 	}()
 
@@ -353,7 +354,7 @@ func (r *ReceiverReconciler) markTerminal(obj *apiv1.Receiver, log logr.Logger, 
 	conditions.MarkStalled(obj, reason, "%s", errMsg)
 	obj.Status.ObservedGeneration = obj.Generation
 	log.Error(err, prefix)
-	r.Event(obj, corev1.EventTypeWarning, reason, errMsg)
+	r.Eventf(obj, nil, corev1.EventTypeWarning, reason, eventv1.ActionFailed, "%s", errMsg)
 }
 
 // token extract the token value from the secret object

--- a/internal/controller/receiver_controller_test.go
+++ b/internal/controller/receiver_controller_test.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -187,7 +187,7 @@ func TestReceiverReconciler_deleteBeforeFinalizer(t *testing.T) {
 
 	r := &ReceiverReconciler{
 		Client:        k8sClient,
-		EventRecorder: record.NewFakeRecorder(32),
+		EventRecorder: events.NewFakeRecorder(32),
 	}
 	// NOTE: Only a real API server responds with an error in this scenario.
 	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(receiver)})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -77,14 +77,14 @@ func TestMain(m *testing.M) {
 	if err := (&AlertReconciler{
 		Client:         testEnv,
 		ControllerName: controllerName,
-		EventRecorder:  testEnv.GetEventRecorderFor(controllerName),
+		EventRecorder:  testEnv.GetEventRecorder(controllerName),
 	}).SetupWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Failed to start AlertReconciler: %v", err))
 	}
 
 	if err := (&ProviderReconciler{
 		Client:        testEnv,
-		EventRecorder: testEnv.GetEventRecorderFor(controllerName),
+		EventRecorder: testEnv.GetEventRecorder(controllerName),
 	}).SetupWithManager(testEnv); err != nil {
 		panic(fmt.Sprintf("Failed to start ProviderReconciler: %v", err))
 	}
@@ -93,7 +93,7 @@ func TestMain(m *testing.M) {
 		Client:         testEnv,
 		Metrics:        testMetricsH,
 		ControllerName: controllerName,
-		EventRecorder:  testEnv.GetEventRecorderFor(controllerName),
+		EventRecorder:  testEnv.GetEventRecorder(controllerName),
 	}).SetupWithManager(testEnv, ReceiverReconcilerOptions{
 		RateLimiter:           controller.GetDefaultRateLimiter(),
 		WatchConfigsPredicate: predicate.Not(predicate.Funcs{}),

--- a/internal/notifier/alertmanager.go
+++ b/internal/notifier/alertmanager.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 type Alertmanager struct {

--- a/internal/notifier/alertmanager_fuzz_test.go
+++ b/internal/notifier/alertmanager_fuzz_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_AlertManager(f *testing.F) {

--- a/internal/notifier/azure_devops.go
+++ b/internal/notifier/azure_devops.go
@@ -27,7 +27,7 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/git"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/auth/azure"
 	"github.com/fluxcd/pkg/cache"

--- a/internal/notifier/azure_devops_fuzz_test.go
+++ b/internal/notifier/azure_devops_fuzz_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 const apiLocations = `{"count":0,"value":[{"area":"","id":"428dd4fb-fda5-4722-af02-9313b80305da","routeTemplate":"","resourceName":"","maxVersion":"6.0","minVersion":"5.0","releasedVersion":"6.0"}]}`

--- a/internal/notifier/azure_devops_test.go
+++ b/internal/notifier/azure_devops_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v6/git"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/notifier/azure_eventhub.go
+++ b/internal/notifier/azure_eventhub.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/auth/azure"
 	"github.com/fluxcd/pkg/cache"
 )

--- a/internal/notifier/bitbucket.go
+++ b/internal/notifier/bitbucket.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/ktrysmt/go-bitbucket"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 )
 

--- a/internal/notifier/bitbucket_fuzz_test.go
+++ b/internal/notifier/bitbucket_fuzz_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_Bitbucket(f *testing.F) {

--- a/internal/notifier/bitbucketserver.go
+++ b/internal/notifier/bitbucketserver.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/hashicorp/go-retryablehttp"
 )

--- a/internal/notifier/bitbucketserver_test.go
+++ b/internal/notifier/bitbucketserver_test.go
@@ -27,7 +27,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/notifier/client_test.go
+++ b/internal/notifier/client_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/hashicorp/go-retryablehttp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/notifier/datadog.go
+++ b/internal/notifier/datadog.go
@@ -27,7 +27,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 type DataDog struct {

--- a/internal/notifier/datadog_fuzz_test.go
+++ b/internal/notifier/datadog_fuzz_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	. "github.com/onsi/gomega"
 )
 

--- a/internal/notifier/discord.go
+++ b/internal/notifier/discord.go
@@ -23,7 +23,7 @@ import (
 	"path"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 // Discord holds the hook URL

--- a/internal/notifier/discord_fuzz_test.go
+++ b/internal/notifier/discord_fuzz_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_Discord(f *testing.F) {

--- a/internal/notifier/forwarder.go
+++ b/internal/notifier/forwarder.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"net/url"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 
 	"github.com/hashicorp/go-retryablehttp"
 )

--- a/internal/notifier/forwarder_fuzz_test.go
+++ b/internal/notifier/forwarder_fuzz_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_Forwarder(f *testing.F) {

--- a/internal/notifier/forwarder_test.go
+++ b/internal/notifier/forwarder_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func TestForwarder_New(t *testing.T) {
@@ -89,7 +89,7 @@ func TestForwarder_Post(t *testing.T) {
 		{
 			name:       "non-empty HMAC key adds signature header",
 			hmacKey:    []byte("7152fed34dd6149a7c75a276c510da27cb6f82b0"),
-			hmacHeader: "sha256=65b018549b1254e7226d1c08f9567ee45bc9de0fc4e7b1a40253f9a018b08be7",
+			hmacHeader: "sha256=2662a6dd1a887c05183aa5b9787d5ed92116199f09c7b3c7908ee3bd20bc60d9",
 			xSigHeader: "should be overwritten with actual signature",
 		},
 	}

--- a/internal/notifier/git_change_request_comment.go
+++ b/internal/notifier/git_change_request_comment.go
@@ -19,7 +19,7 @@ package notifier
 import (
 	"fmt"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 // changeRequestComment contains shared logic for change request comment providers

--- a/internal/notifier/gitea.go
+++ b/internal/notifier/gitea.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"code.gitea.io/sdk/gitea"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 	ctrl "sigs.k8s.io/controller-runtime"
 )

--- a/internal/notifier/gitea_pull_request_comment.go
+++ b/internal/notifier/gitea_pull_request_comment.go
@@ -25,7 +25,7 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 type GiteaPullRequestComment struct {

--- a/internal/notifier/gitea_test.go
+++ b/internal/notifier/gitea_test.go
@@ -21,13 +21,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	testproxy "github.com/fluxcd/notification-controller/tests/proxy"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	testproxy "github.com/fluxcd/notification-controller/tests/proxy"
+
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/internal/notifier/github.go
+++ b/internal/notifier/github.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-github/v64/github"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 )
 

--- a/internal/notifier/github_dispatch.go
+++ b/internal/notifier/github_dispatch.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-github/v64/github"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 type GitHubDispatch struct {

--- a/internal/notifier/github_dispatch_fuzz_test.go
+++ b/internal/notifier/github_dispatch_fuzz_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_GitHub_Dispatch(f *testing.F) {

--- a/internal/notifier/github_fuzz_test.go
+++ b/internal/notifier/github_fuzz_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_GitHub(f *testing.F) {

--- a/internal/notifier/github_pull_request_comment.go
+++ b/internal/notifier/github_pull_request_comment.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/google/go-github/v64/github"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 type GitHubPullRequestComment struct {

--- a/internal/notifier/gitlab.go
+++ b/internal/notifier/gitlab.go
@@ -25,7 +25,7 @@ import (
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 )
 

--- a/internal/notifier/gitlab_fuzz_test.go
+++ b/internal/notifier/gitlab_fuzz_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_GitLab(f *testing.F) {

--- a/internal/notifier/gitlab_merge_request_comment.go
+++ b/internal/notifier/gitlab_merge_request_comment.go
@@ -27,7 +27,7 @@ import (
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 type GitLabMergeRequestComment struct {

--- a/internal/notifier/google_chat.go
+++ b/internal/notifier/google_chat.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 // Slack holds the hook URL

--- a/internal/notifier/google_chat_fuzz_test.go
+++ b/internal/notifier/google_chat_fuzz_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_GoogleChat(f *testing.F) {

--- a/internal/notifier/google_pubsub.go
+++ b/internal/notifier/google_pubsub.go
@@ -26,7 +26,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 type (

--- a/internal/notifier/google_pubsub_test.go
+++ b/internal/notifier/google_pubsub_test.go
@@ -23,7 +23,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func TestNewGooglePubSub(t *testing.T) {
@@ -89,12 +89,12 @@ func TestGooglePubSubPost(t *testing.T) {
 			event: eventv1.Event{
 				Metadata: map[string]string{"foo": "bar"},
 			},
-			expectedEventPayload: `{"involvedObject":{},"severity":"","timestamp":null,"message":"","reason":"","metadata":{"foo":"bar"},"reportingController":""}`,
+			expectedEventPayload: `{"involvedObject":{},"severity":"","timestamp":null,"message":"","reason":"","action":"","metadata":{"foo":"bar"},"reportingController":""}`,
 			publishShouldExecute: true,
 		},
 		{
 			name:                 "publish error is relayed",
-			expectedEventPayload: `{"involvedObject":{},"severity":"","timestamp":null,"message":"","reason":"","reportingController":""}`,
+			expectedEventPayload: `{"involvedObject":{},"severity":"","timestamp":null,"message":"","reason":"","action":"","reportingController":""}`,
 			topicName:            "projects/projectID/topics/topicID",
 			publishErr:           errors.New("publish error"),
 			expectedErr:          errors.New("publish error"),
@@ -104,7 +104,7 @@ func TestGooglePubSubPost(t *testing.T) {
 			name:                 "topic and attributes are relayed to the internal client",
 			topicID:              "topicID",
 			attrs:                map[string]string{"foo": "bar"},
-			expectedEventPayload: `{"involvedObject":{},"severity":"","timestamp":null,"message":"","reason":"","reportingController":""}`,
+			expectedEventPayload: `{"involvedObject":{},"severity":"","timestamp":null,"message":"","reason":"","action":"","reportingController":""}`,
 			publishShouldExecute: true,
 		},
 	}

--- a/internal/notifier/grafana.go
+++ b/internal/notifier/grafana.go
@@ -23,7 +23,7 @@ import (
 	"net/url"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/hashicorp/go-retryablehttp"
 )
 

--- a/internal/notifier/grafana_fuzz_test.go
+++ b/internal/notifier/grafana_fuzz_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_Grafana(f *testing.F) {

--- a/internal/notifier/lark.go
+++ b/internal/notifier/lark.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 type Lark struct {

--- a/internal/notifier/lark_fuzz_test.go
+++ b/internal/notifier/lark_fuzz_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_Lark(f *testing.F) {

--- a/internal/notifier/markdown.go
+++ b/internal/notifier/markdown.go
@@ -21,7 +21,7 @@ import (
 	"slices"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 // formatMarkdownPost formats the event for Markdown rendering engines.

--- a/internal/notifier/matrix.go
+++ b/internal/notifier/matrix.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/hashicorp/go-retryablehttp"
 )
 

--- a/internal/notifier/matrix_fuzz_test.go
+++ b/internal/notifier/matrix_fuzz_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_Matrix(f *testing.F) {

--- a/internal/notifier/matrix_test.go
+++ b/internal/notifier/matrix_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +32,7 @@ func TestSha1Sum(t *testing.T) {
 				ReportingController: "",
 				ReportingInstance:   "",
 			},
-			sha1: "37d91b4f6a1e44c6a38273b0a0fd408fade7b0f5",
+			sha1: "b483201be9dd568ab4db38f53bc19fc82da23943",
 		},
 	}
 

--- a/internal/notifier/nats.go
+++ b/internal/notifier/nats.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
 	"sigs.k8s.io/controller-runtime/pkg/log"

--- a/internal/notifier/nats_test.go
+++ b/internal/notifier/nats_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/nats-io/nats.go"
 	. "github.com/onsi/gomega"
 )
@@ -192,13 +192,13 @@ func TestNATSPost(t *testing.T) {
 			event: eventv1.Event{
 				Metadata: map[string]string{"foo": "bar"},
 			},
-			expectedEventPayload: `{"involvedObject":{},"severity":"","timestamp":null,"message":"","reason":"","metadata":{"foo":"bar"},"reportingController":""}`,
+			expectedEventPayload: `{"involvedObject":{},"severity":"","timestamp":null,"message":"","reason":"","action":"","metadata":{"foo":"bar"},"reportingController":""}`,
 			publishShouldExecute: true,
 		},
 		{
 			name:                 "publish error is wrapped and relayed",
 			subject:              "test",
-			expectedEventPayload: `{"involvedObject":{},"severity":"","timestamp":null,"message":"","reason":"","reportingController":""}`,
+			expectedEventPayload: `{"involvedObject":{},"severity":"","timestamp":null,"message":"","reason":"","action":"","reportingController":""}`,
 			publishErr:           errors.New("publish error"),
 			expectedErr:          fmt.Errorf("error publishing event to subject test: %w", errors.New("publish error")),
 			publishShouldExecute: true,

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -19,7 +19,7 @@ package notifier
 import (
 	"context"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 // OperationPost is the operation name used in cache event metrics

--- a/internal/notifier/opsgenie.go
+++ b/internal/notifier/opsgenie.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"net/url"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/hashicorp/go-retryablehttp"
 )
 

--- a/internal/notifier/opsgenie_fuzz_test.go
+++ b/internal/notifier/opsgenie_fuzz_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_OpsGenie(f *testing.F) {

--- a/internal/notifier/opsgenie_test.go
+++ b/internal/notifier/opsgenie_test.go
@@ -24,7 +24,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	. "github.com/onsi/gomega"
 )
 
@@ -42,7 +42,7 @@ func TestOpsgenie_Post(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		event func() v1beta1.Event
+		event func() eventv1.Event
 	}{
 		{
 			name:  "test event",
@@ -50,7 +50,7 @@ func TestOpsgenie_Post(t *testing.T) {
 		},
 		{
 			name: "test event with empty metadata",
-			event: func() v1beta1.Event {
+			event: func() eventv1.Event {
 				events := testEvent()
 				events.Metadata = nil
 				return events

--- a/internal/notifier/otel.go
+++ b/internal/notifier/otel.go
@@ -37,7 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 
 	apiv1beta3 "github.com/fluxcd/notification-controller/api/v1beta3"
 )

--- a/internal/notifier/otel_test.go
+++ b/internal/notifier/otel_test.go
@@ -23,10 +23,9 @@ import (
 	"testing"
 	"time"
 
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/fluxcd/pkg/apis/event/v1beta1"
 )
 
 func TestOTEL_Post(t *testing.T) {
@@ -44,11 +43,11 @@ func TestOTEL_Post(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		event func() v1beta1.Event
+		event func() eventv1.Event
 	}{
 		{
 			name: "test event",
-			event: func() v1beta1.Event {
+			event: func() eventv1.Event {
 				e := testEvent()
 				// Mocking the data provided by alert.eventMetadata
 				e.Metadata["cluster"] = "my-cluster"

--- a/internal/notifier/pagerduty.go
+++ b/internal/notifier/pagerduty.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/PagerDuty/go-pagerduty"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 )
 

--- a/internal/notifier/pagerduty_fuzz_test.go
+++ b/internal/notifier/pagerduty_fuzz_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_PagerDuty(f *testing.F) {

--- a/internal/notifier/pagerduty_test.go
+++ b/internal/notifier/pagerduty_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 )
 

--- a/internal/notifier/rocket.go
+++ b/internal/notifier/rocket.go
@@ -23,7 +23,7 @@ import (
 	"net/url"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 // Rocket holds the hook URL

--- a/internal/notifier/rocket_fuzz_test.go
+++ b/internal/notifier/rocket_fuzz_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_Rocket(f *testing.F) {

--- a/internal/notifier/sentry.go
+++ b/internal/notifier/sentry.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"net/http"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/getsentry/sentry-go"
 )
 

--- a/internal/notifier/sentry_test.go
+++ b/internal/notifier/sentry_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/getsentry/sentry-go"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -25,7 +25,7 @@ import (
 	"net/url"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/hashicorp/go-retryablehttp"
 )
 

--- a/internal/notifier/slack_fuzz_test.go
+++ b/internal/notifier/slack_fuzz_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_Slack(f *testing.F) {

--- a/internal/notifier/teams.go
+++ b/internal/notifier/teams.go
@@ -24,7 +24,7 @@ import (
 	"slices"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 const (

--- a/internal/notifier/teams_fuzz_test.go
+++ b/internal/notifier/teams_fuzz_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_MSTeams(f *testing.F) {

--- a/internal/notifier/telegram.go
+++ b/internal/notifier/telegram.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 const (

--- a/internal/notifier/util.go
+++ b/internal/notifier/util.go
@@ -27,7 +27,7 @@ import (
 	"github.com/fluxcd/pkg/git"
 
 	giturls "github.com/chainguard-dev/git-urls"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func parseGitAddress(s string) (string, string, error) {

--- a/internal/notifier/util_fuzz_test.go
+++ b/internal/notifier/util_fuzz_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_Util_ParseGitAddress(f *testing.F) {

--- a/internal/notifier/util_test.go
+++ b/internal/notifier/util_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func TestUtil_NameAndDescription(t *testing.T) {

--- a/internal/notifier/webex.go
+++ b/internal/notifier/webex.go
@@ -23,7 +23,7 @@ import (
 	"net/url"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/hashicorp/go-retryablehttp"
 )
 

--- a/internal/notifier/webex_fuzz_test.go
+++ b/internal/notifier/webex_fuzz_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 func Fuzz_Webex(f *testing.F) {

--- a/internal/notifier/zulip.go
+++ b/internal/notifier/zulip.go
@@ -23,7 +23,7 @@ import (
 	"net/url"
 	"strings"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 )
 
 type Zulip struct {

--- a/internal/notifier/zulip_test.go
+++ b/internal/notifier/zulip_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 
 	"github.com/fluxcd/notification-controller/internal/notifier"
 )

--- a/internal/server/event_handlers.go
+++ b/internal/server/event_handlers.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/auth"
 	"github.com/fluxcd/pkg/cache"
 	"github.com/fluxcd/pkg/masktoken"
@@ -94,7 +94,7 @@ func (s *EventServer) handleEvent() func(w http.ResponseWriter, r *http.Request)
 			dropped, err := s.dispatchNotification(ctx, event, alert)
 			if err != nil {
 				alertLogger.Error(err, "failed to dispatch notification")
-				s.Eventf(alert, corev1.EventTypeWarning, "NotificationDispatchFailed",
+				s.Eventf(alert, nil, corev1.EventTypeWarning, "NotificationDispatchFailed", eventv1.ActionFailed,
 					"failed to dispatch notification for %s: %s", involvedObjectString(event.InvolvedObject), err)
 				continue
 			}
@@ -208,8 +208,8 @@ func (s *EventServer) messageIsIncluded(ctx context.Context, msg string, alert *
 			}
 		} else {
 			log.FromContext(ctx).Error(err, fmt.Sprintf("failed to compile inclusion regex: %s", exp))
-			s.Eventf(alert, corev1.EventTypeWarning,
-				"InvalidConfig", "failed to compile inclusion regex: %s", exp)
+			s.Eventf(alert, nil, corev1.EventTypeWarning,
+				"InvalidConfig", eventv1.ActionValidating, "failed to compile inclusion regex: %s", exp)
 		}
 	}
 	return false
@@ -229,7 +229,7 @@ func (s *EventServer) messageIsExcluded(ctx context.Context, msg string, alert *
 			}
 		} else {
 			log.FromContext(ctx).Error(err, fmt.Sprintf("failed to compile exclusion regex: %s", exp))
-			s.Eventf(alert, corev1.EventTypeWarning, "InvalidConfig",
+			s.Eventf(alert, nil, corev1.EventTypeWarning, "InvalidConfig", eventv1.ActionValidating,
 				"failed to compile exclusion regex: %s", exp)
 		}
 	}
@@ -263,7 +263,7 @@ func (s *EventServer) dispatchNotification(ctx context.Context,
 				err = errors.New(maskedErrStr)
 			}
 			log.FromContext(ctx).Error(err, "failed to send notification")
-			s.Eventf(alert, corev1.EventTypeWarning, "NotificationDispatchFailed",
+			s.Eventf(alert, nil, corev1.EventTypeWarning, "NotificationDispatchFailed", eventv1.ActionFailed,
 				"failed to send notification for %s: %s", involvedObjectString(e.InvolvedObject), err)
 		}
 	}(params.sender, *params.event)
@@ -613,7 +613,7 @@ func (s *EventServer) eventMatchesAlertSource(ctx context.Context, event *eventv
 		Name:      event.InvolvedObject.Name,
 	}, &obj); err != nil {
 		logger.Error(err, "error getting the involved object")
-		s.Eventf(alert, corev1.EventTypeWarning, "SourceFetchFailed",
+		s.Eventf(alert, nil, corev1.EventTypeWarning, "SourceFetchFailed", eventv1.ActionFetching,
 			"error getting source object %s", involvedObjectString(event.InvolvedObject))
 		return false
 	}
@@ -623,7 +623,7 @@ func (s *EventServer) eventMatchesAlertSource(ctx context.Context, event *eventv
 	})
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("error using matchLabels from event source %s", crossNSObjectRefString(source)))
-		s.Eventf(alert, corev1.EventTypeWarning, "InvalidConfig",
+		s.Eventf(alert, nil, corev1.EventTypeWarning, "InvalidConfig", "",
 			"error using matchLabels from event source %s", crossNSObjectRefString(source))
 		return false
 	}
@@ -710,7 +710,7 @@ func (s *EventServer) combineEventMetadata(ctx context.Context, event *eventv1.E
 		const msg = "metadata key conflicts detected (please refer to the Alert API docs and Flux RFC 0008 for more information)"
 		slices.SortFunc(conflictingKeys, func(a, b *keyConflict) int { return strings.Compare(a.Key, b.Key) })
 		l.Info("warning: "+msg, "conflictingKeys", conflictingKeys)
-		s.AnnotatedEventf(alert, conflictEventAnnotations, corev1.EventTypeWarning, "MetadataAppendFailed", "%s", msg)
+		s.Eventf(alert, nil, corev1.EventTypeWarning, "MetadataAppendFailed", "", "%s", msg)
 	}
 
 	if len(metadata) > 0 {

--- a/internal/server/event_handlers_test.go
+++ b/internal/server/event_handlers_test.go
@@ -38,11 +38,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/auth"
 
@@ -291,7 +291,7 @@ func TestFilterAlertsForEvent(t *testing.T) {
 			eventServer := EventServer{
 				kubeClient:    builder.Build(),
 				logger:        log.Log,
-				EventRecorder: record.NewFakeRecorder(32),
+				EventRecorder: events.NewFakeRecorder(32),
 			}
 
 			result := eventServer.filterAlertsForEvent(context.TODO(), alerts, testEvent)
@@ -375,7 +375,7 @@ func TestDispatchNotification(t *testing.T) {
 			eventServer := EventServer{
 				kubeClient:    builder.Build(),
 				logger:        log.Log,
-				EventRecorder: record.NewFakeRecorder(32),
+				EventRecorder: events.NewFakeRecorder(32),
 			}
 
 			_, err := eventServer.dispatchNotification(context.TODO(), testEvent, alert)
@@ -593,7 +593,7 @@ func TestGetNotificationParams(t *testing.T) {
 				kubeClient:           builder.Build(),
 				logger:               log.Log,
 				noCrossNamespaceRefs: tt.noCrossNSRefs,
-				EventRecorder:        record.NewFakeRecorder(32),
+				EventRecorder:        events.NewFakeRecorder(32),
 			}
 
 			params, dropped, err := eventServer.getNotificationParams(context.TODO(), event, alert)
@@ -1380,7 +1380,7 @@ func TestEventMatchesAlert(t *testing.T) {
 			eventServer := EventServer{
 				kubeClient:    builder.Build(),
 				logger:        log.Log,
-				EventRecorder: record.NewFakeRecorder(32),
+				EventRecorder: events.NewFakeRecorder(32),
 			}
 			alert := &apiv1beta3.Alert{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1452,7 +1452,7 @@ func TestCombineEventMetadata(t *testing.T) {
 			expectedMetadata: map[string]string{
 				"summary": "alertSummary",
 			},
-			conflictEvent: "Warning MetadataAppendFailed metadata key conflicts detected (please refer to the Alert API docs and Flux RFC 0008 for more information) map[summary:involved object annotations, Alert object .spec.summary]",
+			conflictEvent: "Warning MetadataAppendFailed metadata key conflicts detected (please refer to the Alert API docs and Flux RFC 0008 for more information)",
 		},
 		"alert event metadata is overriden by summary": {
 			event: eventv1.Event{},
@@ -1467,7 +1467,7 @@ func TestCombineEventMetadata(t *testing.T) {
 			expectedMetadata: map[string]string{
 				"summary": "alertSummary",
 			},
-			conflictEvent: "Warning MetadataAppendFailed metadata key conflicts detected (please refer to the Alert API docs and Flux RFC 0008 for more information) map[summary:Alert object .spec.eventMetadata, Alert object .spec.summary]",
+			conflictEvent: "Warning MetadataAppendFailed metadata key conflicts detected (please refer to the Alert API docs and Flux RFC 0008 for more information)",
 		},
 		"summary is overriden by controller metadata": {
 			event: eventv1.Event{
@@ -1483,7 +1483,7 @@ func TestCombineEventMetadata(t *testing.T) {
 			expectedMetadata: map[string]string{
 				"summary": "controllerSummary",
 			},
-			conflictEvent: "Warning MetadataAppendFailed metadata key conflicts detected (please refer to the Alert API docs and Flux RFC 0008 for more information) map[summary:Alert object .spec.summary, involved object controller metadata]",
+			conflictEvent: "Warning MetadataAppendFailed metadata key conflicts detected (please refer to the Alert API docs and Flux RFC 0008 for more information)",
 		},
 		"precedence order in RFC 0008 is honered": {
 			event: eventv1.Event{
@@ -1513,13 +1513,13 @@ func TestCombineEventMetadata(t *testing.T) {
 				"alertMetadataOverridenByController":  "controllerMetadataValue2",
 				"controllerMetadata":                  "controllerMetadataValue3",
 			},
-			conflictEvent: "Warning MetadataAppendFailed metadata key conflicts detected (please refer to the Alert API docs and Flux RFC 0008 for more information) map[alertMetadataOverridenByController:Alert object .spec.eventMetadata, involved object controller metadata objectMetadataOverridenByAlert:involved object annotations, Alert object .spec.eventMetadata objectMetadataOverridenByController:involved object annotations, involved object controller metadata]",
+			conflictEvent: "Warning MetadataAppendFailed metadata key conflicts detected (please refer to the Alert API docs and Flux RFC 0008 for more information)",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			eventRecorder := record.NewFakeRecorder(1)
+			eventRecorder := events.NewFakeRecorder(1)
 			s := &EventServer{
 				logger:        log.Log,
 				EventRecorder: eventRecorder,

--- a/internal/server/event_server.go
+++ b/internal/server/event_server.go
@@ -33,11 +33,11 @@ import (
 	"github.com/sethvargo/go-limiter/httplimit"
 	"github.com/slok/go-http-metrics/middleware"
 	"github.com/slok/go-http-metrics/middleware/std"
-	kuberecorder "k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/cache"
 )
 
@@ -55,12 +55,12 @@ type EventServer struct {
 	noCrossNamespaceRefs  bool
 	exportHTTPPathMetrics bool
 	tokenCache            *cache.TokenCache
-	kuberecorder.EventRecorder
+	events.EventRecorder
 }
 
 // NewEventServer returns an HTTP server that handles events
 func NewEventServer(port string, logger logr.Logger, kubeClient client.Client,
-	eventRecorder kuberecorder.EventRecorder, noCrossNamespaceRefs bool,
+	eventRecorder events.EventRecorder, noCrossNamespaceRefs bool,
 	exportHTTPPathMetrics bool, tokenCache *cache.TokenCache) *EventServer {
 	return &EventServer{
 		port:                  port,

--- a/internal/server/event_server_test.go
+++ b/internal/server/event_server_test.go
@@ -40,11 +40,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 
 	apiv1 "github.com/fluxcd/notification-controller/api/v1"
@@ -137,7 +137,7 @@ func TestEventServer(t *testing.T) {
 		t.Fatalf("failed to create memory storage")
 	}
 	eventServer := NewEventServer("127.0.0.1:"+eventServerPort,
-		log.Log, kclient, record.NewFakeRecorder(32), true, true, nil)
+		log.Log, kclient, events.NewFakeRecorder(32), true, true, nil)
 	stopCh := make(chan struct{})
 	go eventServer.ListenAndServe(stopCh, eventMdlw, store)
 	defer close(stopCh)

--- a/internal/server/provider_change_request.go
+++ b/internal/server/provider_change_request.go
@@ -17,7 +17,7 @@ limitations under the License.
 package server
 
 import (
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 
 	apiv1beta3 "github.com/fluxcd/notification-controller/api/v1beta3"
 )

--- a/internal/server/provider_commit_status.go
+++ b/internal/server/provider_commit_status.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/cel-go/common/types"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/runtime/cel"
 
 	apiv1beta3 "github.com/fluxcd/notification-controller/api/v1beta3"

--- a/internal/server/provider_commit_status_test.go
+++ b/internal/server/provider_commit_status_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/main.go
+++ b/main.go
@@ -235,7 +235,7 @@ func main() {
 
 	if err = (&controller.ProviderReconciler{
 		Client:        mgr.GetClient(),
-		EventRecorder: mgr.GetEventRecorderFor(controllerName),
+		EventRecorder: mgr.GetEventRecorder(controllerName),
 		TokenCache:    tokenCache,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Provider")
@@ -245,7 +245,7 @@ func main() {
 	if err = (&controller.AlertReconciler{
 		Client:         mgr.GetClient(),
 		ControllerName: controllerName,
-		EventRecorder:  mgr.GetEventRecorderFor(controllerName),
+		EventRecorder:  mgr.GetEventRecorder(controllerName),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Alert")
 		os.Exit(1)
@@ -255,7 +255,7 @@ func main() {
 		Client:         mgr.GetClient(),
 		ControllerName: controllerName,
 		Metrics:        metricsH,
-		EventRecorder:  mgr.GetEventRecorderFor(controllerName),
+		EventRecorder:  mgr.GetEventRecorder(controllerName),
 	}).SetupWithManager(mgr, controller.ReceiverReconcilerOptions{
 		RateLimiter:           runtimeCtrl.GetRateLimiter(rateLimiterOptions),
 		WatchConfigs:          watchConfigs,
@@ -282,7 +282,7 @@ func main() {
 			Registry: ctrlmetrics.Registry,
 		}),
 	})
-	eventServer := server.NewEventServer(eventsAddr, ctrl.Log, mgr.GetClient(), mgr.GetEventRecorderFor(controllerName), aclOptions.NoCrossNamespaceRefs, exportHTTPPathMetrics, tokenCache)
+	eventServer := server.NewEventServer(eventsAddr, ctrl.Log, mgr.GetClient(), mgr.GetEventRecorder(controllerName), aclOptions.NoCrossNamespaceRefs, exportHTTPPathMetrics, tokenCache)
 	go eventServer.ListenAndServe(ctx.Done(), eventMdlw, store)
 
 	setupLog.Info("starting webhook receiver server", "addr", receiverAddr)


### PR DESCRIPTION
Migrates the controller's event recording from the legacy `k8s.io/client-go/tools/record` interface to `github.com/fluxcd/pkg/runtime/events`, which emits structured `events.k8s.io/v1` Events, and moves the event payload API from `fluxcd/pkg/apis/event/v1beta1` to `fluxcd/pkg/apis/event/v1`.

- Replace `kuberecorder.EventRecorder` with `events.Recorder` in the Alert, Provider and Receiver reconcilers and in the EventServer.
- Switch event emission to the `event/v1` `Eventf` signature, adding an explicit `Action` (Reconciled, Failed, Validating, Fetching) and `Related` object argument.
- Migrate all notifier backends from `event/v1beta1` to `event/v1`; the dispatched payload now carries the `action` field
- Use `mgr.GetEventRecorder` / `testEnv.GetEventRecorder` and `events.NewFakeRecorder` in tests instead of the client-go equivalents.
- Document the new `relatedObject` field and `event/v1` reference in the event spec.
- Bump Kubernetes to 0.37, controller-runtime to 0.25 and the `fluxcd/pkg` modules as a set

Part of https://github.com/fluxcd/flux2/issues/5761