### PR TITLE
Remove GCR audience reconstruction

### DIFF
--- a/api/v1/receiver_types.go
+++ b/api/v1/receiver_types.go
@@ -81,8 +81,7 @@ type ReceiverSpec struct {
 	// to validate the payload authenticity. The Secret must contain a 'token'
 	// key. For GCR receivers, the Secret must also contain an 'email' key
 	// with the IAM service account email configured on the Pub/Sub push
-	// subscription, and may optionally contain an 'audience' key with the
-	// expected OIDC token audience.
+	// subscription, and an 'audience' key with the expected OIDC token audience.
 	// +required
 	SecretRef meta.LocalObjectReference `json:"secretRef"`
 

--- a/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
@@ -130,8 +130,7 @@ spec:
                   to validate the payload authenticity. The Secret must contain a 'token'
                   key. For GCR receivers, the Secret must also contain an 'email' key
                   with the IAM service account email configured on the Pub/Sub push
-                  subscription, and may optionally contain an 'audience' key with the
-                  expected OIDC token audience.
+                  subscription, and an 'audience' key with the expected OIDC token audience.
                 properties:
                   name:
                     description: Name of the referent.

--- a/docs/api/v1/notification.md
+++ b/docs/api/v1/notification.md
@@ -152,8 +152,7 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 to validate the payload authenticity. The Secret must contain a &lsquo;token&rsquo;
 key. For GCR receivers, the Secret must also contain an &lsquo;email&rsquo; key
 with the IAM service account email configured on the Pub/Sub push
-subscription, and may optionally contain an &lsquo;audience&rsquo; key with the
-expected OIDC token audience.</p>
+subscription, and an &lsquo;audience&rsquo; key with the expected OIDC token audience.</p>
 </td>
 </tr>
 <tr>
@@ -373,8 +372,7 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 to validate the payload authenticity. The Secret must contain a &lsquo;token&rsquo;
 key. For GCR receivers, the Secret must also contain an &lsquo;email&rsquo; key
 with the IAM service account email configured on the Pub/Sub push
-subscription, and may optionally contain an &lsquo;audience&rsquo; key with the
-expected OIDC token audience.</p>
+subscription, and an &lsquo;audience&rsquo; key with the expected OIDC token audience.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1/receivers.md
+++ b/docs/spec/v1/receivers.md
@@ -576,7 +576,7 @@ The Secret referenced by `.spec.secretRef.name` must contain the following keys:
 |--------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `token`      | Yes      | Random string used to salt the generated [webhook path](#webhook-path).                                                                                        |
 | `email`      | Yes      | The email of the IAM service account configured on the Pub/Sub push subscription for OIDC authentication.                                                      |
-| `audience`   | No       | The expected `aud` claim in the OIDC token. If omitted, the controller reconstructs it from the incoming request URL, which matches the Pub/Sub default behavior of using the push endpoint URL as the audience. Set this if you configured a custom audience on the Pub/Sub subscription. |
+| `audience`   | Yes      | The expected `aud` claim in the OIDC token.                                                                                                                    |
 
 Example:
 
@@ -591,6 +591,10 @@ type: Opaque
 stringData:
   token: <random token>
   email: <service-account>@<project>.iam.gserviceaccount.com
+  # The default audience set by GCP is the full push endpoint URL, but
+  # you can also choose a custom audience and configure it on the Pub/Sub
+  # subscription.
+  audience: https://<hostname>/hook/<sha256(token+name+namespace)>
 ```
 
 When the verification succeeds, the request payload is unmarshalled to the

--- a/internal/server/receiver_handlers.go
+++ b/internal/server/receiver_handlers.go
@@ -426,34 +426,23 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 			} `json:"message"`
 		}
 
-		expectedEmail, ok := secret.Data["email"]
-		_ = ok
+		expectedEmail := string(secret.Data["email"])
 		// TODO: in Flux 2.9, require the email. this will be a breaking change.
-		// if !ok {
+		// if expectedEmail == "" {
 		// 	return fmt.Errorf("invalid secret data: required field 'email' for GCR receiver")
 		// }
 
-		// Determine the expected audience. If explicitly set in the secret, use
-		// that. Otherwise, reconstruct the webhook URL from the request, which is
-		// the default audience used by GCR when it sends the webhook.
-		audience := string(secret.Data["audience"])
-		if audience == "" {
-			scheme := "https"
-			if r.TLS == nil {
-				if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
-					scheme = proto
-				} else {
-					scheme = "http"
-				}
-			}
-			audience = scheme + "://" + r.Host + r.URL.Path
-		}
+		expectedAudience := string(secret.Data["audience"])
+		// TODO: in Flux 2.9, require the audience. this will be a breaking change.
+		// if expectedAudience == "" {
+		// 	return fmt.Errorf("invalid secret data: required field 'audience' for GCR receiver")
+		// }
 
 		authenticate := authenticateGCRRequest
 		if s.gcrTokenValidator != nil {
 			authenticate = s.gcrTokenValidator
 		}
-		if err := authenticate(ctx, r.Header.Get("Authorization"), string(expectedEmail), audience); err != nil {
+		if err := authenticate(ctx, r.Header.Get("Authorization"), expectedEmail, expectedAudience); err != nil {
 			return fmt.Errorf("cannot authenticate GCR request: %w", err)
 		}
 


### PR DESCRIPTION
Follow up for #1279.

The `audience` must also be present on the secret. (Just like `email`, it will become required in Flux 2.9.)