### PR TITLE
Make Receiver `secretRef` optional for `generic-oidc`

### DIFF
--- a/api/v1/receiver_types.go
+++ b/api/v1/receiver_types.go
@@ -51,6 +51,7 @@ const DefaultOIDCAudience string = "notification-controller"
 // ReceiverSpec defines the desired state of the Receiver.
 // +kubebuilder:validation:XValidation:rule="self.type != 'generic-oidc' || (has(self.oidcProviders) && size(self.oidcProviders) > 0)",message="generic-oidc receivers must define at least one oidcProvider"
 // +kubebuilder:validation:XValidation:rule="self.type == 'generic-oidc' || !has(self.oidcProviders) || size(self.oidcProviders) == 0",message="oidcProviders can only be set when type is generic-oidc"
+// +kubebuilder:validation:XValidation:rule="self.type == 'generic-oidc' || has(self.secretRef)",message="secretRef is required when type is not generic-oidc"
 type ReceiverSpec struct {
 	// Type of webhook sender, used to determine
 	// the validation procedure and payload deserialization.
@@ -89,8 +90,11 @@ type ReceiverSpec struct {
 	// key. For GCR receivers, the Secret must also contain an 'email' key
 	// with the IAM service account email configured on the Pub/Sub push
 	// subscription, and an 'audience' key with the expected OIDC token audience.
-	// +required
-	SecretRef meta.LocalObjectReference `json:"secretRef"`
+	//
+	// Required for all receiver types except 'generic-oidc', which authenticates
+	// requests using the OIDC token instead.
+	// +optional
+	SecretRef *meta.LocalObjectReference `json:"secretRef,omitempty"`
 
 	// OIDCProviders specifies the OIDC providers used to authenticate incoming
 	// requests when Type is 'generic-oidc'. The provider whose IssuerURL matches

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1
 
 import (
+	"github.com/fluxcd/pkg/apis/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -181,7 +182,11 @@ func (in *ReceiverSpec) DeepCopyInto(out *ReceiverSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.SecretRef = in.SecretRef
+	if in.SecretRef != nil {
+		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(meta.LocalObjectReference)
+		**out = **in
+	}
 	if in.OIDCProviders != nil {
 		in, out := &in.OIDCProviders, &out.OIDCProviders
 		*out = make([]OIDCProvider, len(*in))

--- a/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
@@ -216,6 +216,9 @@ spec:
                   key. For GCR receivers, the Secret must also contain an 'email' key
                   with the IAM service account email configured on the Pub/Sub push
                   subscription, and an 'audience' key with the expected OIDC token audience.
+
+                  Required for all receiver types except 'generic-oidc', which authenticates
+                  requests using the OIDC token instead.
                 properties:
                   name:
                     description: Name of the referent.
@@ -249,7 +252,6 @@ spec:
                 type: string
             required:
             - resources
-            - secretRef
             - type
             type: object
             x-kubernetes-validations:
@@ -259,6 +261,8 @@ spec:
             - message: oidcProviders can only be set when type is generic-oidc
               rule: self.type == 'generic-oidc' || !has(self.oidcProviders) || size(self.oidcProviders)
                 == 0
+            - message: secretRef is required when type is not generic-oidc
+              rule: self.type == 'generic-oidc' || has(self.secretRef)
           status:
             default:
               observedGeneration: -1

--- a/docs/api/v1/notification.md
+++ b/docs/api/v1/notification.md
@@ -148,11 +148,14 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>SecretRef specifies the Secret containing the token used
 to validate the payload authenticity. The Secret must contain a &lsquo;token&rsquo;
 key. For GCR receivers, the Secret must also contain an &lsquo;email&rsquo; key
 with the IAM service account email configured on the Pub/Sub push
 subscription, and an &lsquo;audience&rsquo; key with the expected OIDC token audience.</p>
+<p>Required for all receiver types except &lsquo;generic-oidc&rsquo;, which authenticates
+requests using the OIDC token instead.</p>
 </td>
 </tr>
 <tr>
@@ -558,11 +561,14 @@ github.com/fluxcd/pkg/apis/meta.LocalObjectReference
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>SecretRef specifies the Secret containing the token used
 to validate the payload authenticity. The Secret must contain a &lsquo;token&rsquo;
 key. For GCR receivers, the Secret must also contain an &lsquo;email&rsquo; key
 with the IAM service account email configured on the Pub/Sub push
 subscription, and an &lsquo;audience&rsquo; key with the expected OIDC token audience.</p>
+<p>Required for all receiver types except &lsquo;generic-oidc&rsquo;, which authenticates
+requests using the OIDC token instead.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1/receivers.md
+++ b/docs/spec/v1/receivers.md
@@ -274,8 +274,6 @@ metadata:
   namespace: default
 spec:
   type: generic-oidc
-  secretRef:
-    name: webhook-token
   oidcProviders:
     # audience defaults to 'notification-controller'.
     - issuerURL: https://token.actions.githubusercontent.com
@@ -922,9 +920,14 @@ This would look for an annotation "update-image" on the resource, and match it t
 
 ### Secret reference
 
-`.spec.secretRef.name` is a required field to specify a name reference to a
-Secret in the same namespace as the Receiver. The Secret must contain a `token`
-key, whose value is a string containing a (random) secret token.
+`.spec.secretRef.name` specifies a name reference to a Secret in the same
+namespace as the Receiver. The Secret must contain a `token` key, whose value is
+a string containing a (random) secret token.
+
+It is required for all receiver types except [`generic-oidc`](#generic-oidc),
+which authenticates requests using the OIDC token instead. When omitted, the
+[webhook path](#webhook-path) is derived from the Receiver name and namespace
+only.
 
 This token is used to salt the generated [webhook path](#webhook-path), and
 depending on the Receiver [type](#supported-receiver-types), to verify the

--- a/internal/controller/receiver_controller.go
+++ b/internal/controller/receiver_controller.go
@@ -79,6 +79,9 @@ func (r *ReceiverReconciler) SetupWithManager(mgr ctrl.Manager, opts ReceiverRec
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &apiv1.Receiver{},
 		secretRefIndex, func(obj client.Object) []string {
 			receiver := obj.(*apiv1.Receiver)
+			if receiver.Spec.SecretRef == nil {
+				return nil
+			}
 			return []string{fmt.Sprintf("%s/%s", receiver.GetNamespace(), receiver.Spec.SecretRef.Name)}
 		}); err != nil {
 	}
@@ -314,6 +317,9 @@ func validateOIDCSpec(obj *apiv1.Receiver) error {
 	if obj.Spec.Type != apiv1.GenericOIDCReceiver && len(obj.Spec.OIDCProviders) > 0 {
 		return fmt.Errorf("oidcProviders can only be set when type is generic-oidc")
 	}
+	if obj.Spec.Type != apiv1.GenericOIDCReceiver && obj.Spec.SecretRef == nil {
+		return fmt.Errorf("secretRef is required when type is not generic-oidc")
+	}
 	return nil
 }
 
@@ -332,6 +338,13 @@ func (r *ReceiverReconciler) markTerminal(obj *apiv1.Receiver, log logr.Logger, 
 
 // token extract the token value from the secret object
 func (r *ReceiverReconciler) token(ctx context.Context, receiver *apiv1.Receiver) (string, error) {
+	// secretRef is optional for generic-oidc receivers, which authenticate
+	// requests using the OIDC token instead of the webhook token. Without a
+	// token the webhook path is derived from the Receiver name and namespace.
+	if receiver.Spec.SecretRef == nil {
+		return "", nil
+	}
+
 	token := ""
 	secretName := types.NamespacedName{
 		Namespace: receiver.GetNamespace(),

--- a/internal/controller/receiver_controller_test.go
+++ b/internal/controller/receiver_controller_test.go
@@ -45,6 +45,53 @@ import (
 	"github.com/fluxcd/notification-controller/internal/server"
 )
 
+func TestValidateOIDCSpec(t *testing.T) {
+	stubProvider := []apiv1.OIDCProvider{{IssuerURL: "https://example.com"}}
+	secretRef := &meta.LocalObjectReference{Name: "webhook-token"}
+
+	tests := []struct {
+		name    string
+		spec    apiv1.ReceiverSpec
+		wantErr string
+	}{
+		{
+			name:    "generic-oidc without oidcProviders is rejected",
+			spec:    apiv1.ReceiverSpec{Type: apiv1.GenericOIDCReceiver},
+			wantErr: "generic-oidc receiver requires at least one oidcProvider",
+		},
+		{
+			name:    "oidcProviders on non-generic-oidc is rejected",
+			spec:    apiv1.ReceiverSpec{Type: apiv1.GenericReceiver, SecretRef: secretRef, OIDCProviders: stubProvider},
+			wantErr: "oidcProviders can only be set when type is generic-oidc",
+		},
+		{
+			name:    "secretRef is required for non-generic-oidc",
+			spec:    apiv1.ReceiverSpec{Type: apiv1.GenericReceiver},
+			wantErr: "secretRef is required when type is not generic-oidc",
+		},
+		{
+			name: "generic-oidc without secretRef is valid",
+			spec: apiv1.ReceiverSpec{Type: apiv1.GenericOIDCReceiver, OIDCProviders: stubProvider},
+		},
+		{
+			name: "non-generic-oidc with secretRef is valid",
+			spec: apiv1.ReceiverSpec{Type: apiv1.GenericReceiver, SecretRef: secretRef},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := validateOIDCSpec(&apiv1.Receiver{Spec: tt.spec})
+			if tt.wantErr == "" {
+				g.Expect(err).NotTo(HaveOccurred())
+				return
+			}
+			g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+		})
+	}
+}
+
 func TestReceiverReconciler_deleteBeforeFinalizer(t *testing.T) {
 	g := NewWithT(t)
 
@@ -65,7 +112,7 @@ func TestReceiverReconciler_deleteBeforeFinalizer(t *testing.T) {
 		Resources: []apiv1.CrossNamespaceObjectReference{
 			{Kind: "Bucket", Name: "Foo"},
 		},
-		SecretRef: meta.LocalObjectReference{Name: "foo-secret"},
+		SecretRef: &meta.LocalObjectReference{Name: "foo-secret"},
 	}
 	// Add a test finalizer to prevent the object from getting deleted.
 	receiver.SetFinalizers([]string{"test-finalizer"})
@@ -121,7 +168,7 @@ func TestReceiverReconciler_Reconcile(t *testing.T) {
 					Kind: "GitRepository",
 				},
 			},
-			SecretRef: meta.LocalObjectReference{
+			SecretRef: &meta.LocalObjectReference{
 				Name: secretName,
 			},
 		},
@@ -368,7 +415,7 @@ func TestReceiverReconciler_EventHandler(t *testing.T) {
 					Kind: "GitRepository",
 				},
 			},
-			SecretRef: meta.LocalObjectReference{
+			SecretRef: &meta.LocalObjectReference{
 				Name: "receiver-secret",
 			},
 		},

--- a/internal/server/receiver_handler_test.go
+++ b/internal/server/receiver_handler_test.go
@@ -98,7 +98,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 				},
@@ -118,7 +118,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GitLabReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 				},
@@ -142,7 +142,7 @@ func Test_handlePayload(t *testing.T) {
 				Spec: apiv1.ReceiverSpec{
 					Type:   apiv1.CDEventsReceiver,
 					Events: []string{"cd.change.merged.v1"},
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 				},
@@ -181,7 +181,7 @@ func Test_handlePayload(t *testing.T) {
 				Spec: apiv1.ReceiverSpec{
 					Type:   apiv1.CDEventsReceiver,
 					Events: []string{"cd.environment.modified.v1"},
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 				},
@@ -219,7 +219,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.CDEventsReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 				},
@@ -257,7 +257,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GitHubReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 				},
@@ -288,7 +288,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericHMACReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 				},
@@ -317,7 +317,7 @@ func Test_handlePayload(t *testing.T) {
 				Spec: apiv1.ReceiverSpec{
 					Type:   apiv1.BitbucketReceiver,
 					Events: []string{"push"},
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 				},
@@ -346,7 +346,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.QuayReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 				},
@@ -372,7 +372,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.HarborReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 				},
@@ -395,7 +395,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "non-existing",
 					},
 				},
@@ -448,7 +448,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -476,7 +476,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -503,7 +503,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -560,7 +560,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -612,7 +612,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -643,7 +643,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -684,7 +684,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -710,7 +710,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -772,7 +772,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -857,7 +857,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -911,7 +911,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GitHubReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -948,7 +948,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GitLabReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -979,7 +979,7 @@ func Test_handlePayload(t *testing.T) {
 				Spec: apiv1.ReceiverSpec{
 					Type:   apiv1.CDEventsReceiver,
 					Events: []string{"cd.change.merged.v1"},
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -1040,7 +1040,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.BitbucketReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -1073,7 +1073,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.QuayReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -1127,7 +1127,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.HarborReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -1168,7 +1168,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.DockerHubReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -1211,7 +1211,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GCRReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "gcr-token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -1263,7 +1263,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GCRReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "gcr-token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -1313,7 +1313,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GCRReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "gcr-token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -1370,7 +1370,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.NexusReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -1410,7 +1410,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.ACRReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{
@@ -1443,7 +1443,7 @@ func Test_handlePayload(t *testing.T) {
 				},
 				Spec: apiv1.ReceiverSpec{
 					Type: apiv1.GenericReceiver,
-					SecretRef: meta.LocalObjectReference{
+					SecretRef: &meta.LocalObjectReference{
 						Name: "token",
 					},
 					Resources: []apiv1.CrossNamespaceObjectReference{

--- a/internal/server/receiver_handlers.go
+++ b/internal/server/receiver_handlers.go
@@ -225,22 +225,27 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 	}
 	r.Body = io.NopCloser(bytes.NewReader(b))
 
-	// Fetch the secret.
-	secret, err := s.secret(ctx, receiver)
-	if err != nil {
-		return fmt.Errorf("unable to read secret, error: %w", err)
-	}
+	// Fetch the secret and extract the token, when a secretRef is set. secretRef
+	// is optional only for generic-oidc receivers, which authenticate requests
+	// using the OIDC token instead of the webhook token.
+	var secret *corev1.Secret
+	var token string
+	if receiver.Spec.SecretRef != nil {
+		secret, err = s.secret(ctx, receiver)
+		if err != nil {
+			return fmt.Errorf("unable to read secret, error: %w", err)
+		}
 
-	// Extract the token from the secret.
-	secretName := types.NamespacedName{
-		Namespace: receiver.GetNamespace(),
-		Name:      receiver.Spec.SecretRef.Name,
+		secretName := types.NamespacedName{
+			Namespace: receiver.GetNamespace(),
+			Name:      receiver.Spec.SecretRef.Name,
+		}
+		tokenBytes, ok := secret.Data["token"]
+		if !ok {
+			return fmt.Errorf("invalid %q secret data: required field 'token'", secretName)
+		}
+		token = string(tokenBytes)
 	}
-	tokenBytes, ok := secret.Data["token"]
-	if !ok {
-		return fmt.Errorf("invalid %q secret data: required field 'token'", secretName)
-	}
-	token := string(tokenBytes)
 
 	logger := s.logger.WithValues(
 		"reconciler kind", apiv1.ReceiverKind,
@@ -426,6 +431,10 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 				PublishTime  time.Time `json:"publishTime"`
 				Subscription string    `json:"subscription"`
 			} `json:"message"`
+		}
+
+		if secret == nil {
+			return fmt.Errorf("secretRef is required for GCR receivers")
 		}
 
 		expectedEmail := string(secret.Data["email"])

--- a/internal/server/receiver_oidc_test.go
+++ b/internal/server/receiver_oidc_test.go
@@ -117,7 +117,7 @@ func newOIDCReceiver(name string, providers []apiv1.OIDCProvider) *apiv1.Receive
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: apiv1.ReceiverSpec{
 			Type:          apiv1.GenericOIDCReceiver,
-			SecretRef:     meta.LocalObjectReference{Name: "token"},
+			SecretRef:     &meta.LocalObjectReference{Name: "token"},
 			OIDCProviders: providers,
 			Resources: []apiv1.CrossNamespaceObjectReference{{
 				APIVersion: apiv1.GroupVersion.String(),


### PR DESCRIPTION
Follow-up for #1306

Today, the `token` inside the secret must be present but can be empty. I was planning to set an empty token in the secret to use in my clusters for `generic-oidc`, but then I realized that we can just make the API simpler and not require the `secretRef` to be set only for `generic-oidc`.