### PR TITLE
Enrich Receiver `resourceFilter` with OIDC claims

### DIFF
--- a/api/v1/receiver_types.go
+++ b/api/v1/receiver_types.go
@@ -80,6 +80,9 @@ type ReceiverSpec struct {
 	// evaluated for each resource referenced in the Resources field when a
 	// webhook is received. If the expression returns false then the controller
 	// will not request a reconciliation for the resource.
+	// The expression can read the resource metadata via 'res' and the webhook
+	// request body via 'req'. For generic-oidc receivers, the verified OIDC
+	// token claims are also available via 'claims'.
 	// When the expression is specified the controller will parse it and mark
 	// the object as terminally failed if the expression is invalid or does not
 	// return a boolean.

--- a/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
@@ -153,6 +153,9 @@ spec:
                   evaluated for each resource referenced in the Resources field when a
                   webhook is received. If the expression returns false then the controller
                   will not request a reconciliation for the resource.
+                  The expression can read the resource metadata via 'res' and the webhook
+                  request body via 'req'. For generic-oidc receivers, the verified OIDC
+                  token claims are also available via 'claims'.
                   When the expression is specified the controller will parse it and mark
                   the object as terminally failed if the expression is invalid or does not
                   return a boolean.

--- a/docs/api/v1/notification.md
+++ b/docs/api/v1/notification.md
@@ -133,6 +133,9 @@ string
 evaluated for each resource referenced in the Resources field when a
 webhook is received. If the expression returns false then the controller
 will not request a reconciliation for the resource.
+The expression can read the resource metadata via &lsquo;res&rsquo; and the webhook
+request body via &lsquo;req&rsquo;. For generic-oidc receivers, the verified OIDC
+token claims are also available via &lsquo;claims&rsquo;.
 When the expression is specified the controller will parse it and mark
 the object as terminally failed if the expression is invalid or does not
 return a boolean.</p>
@@ -546,6 +549,9 @@ string
 evaluated for each resource referenced in the Resources field when a
 webhook is received. If the expression returns false then the controller
 will not request a reconciliation for the resource.
+The expression can read the resource metadata via &lsquo;res&rsquo; and the webhook
+request body via &lsquo;req&rsquo;. For generic-oidc receivers, the verified OIDC
+token claims are also available via &lsquo;claims&rsquo;.
 When the expression is specified the controller will parse it and mark
 the object as terminally failed if the expression is invalid or does not
 return a boolean.</p>

--- a/docs/spec/v1/receivers.md
+++ b/docs/spec/v1/receivers.md
@@ -917,6 +917,18 @@ This would look for an annotation "update-image" on the resource, and match it t
 
 **Note:** Currently the `resource` value in the CEL expression only provides the object metadata, this means you can access things like `res.metadata.labels`, `res.metadata.annotations` and `res.metadata.name`.
 
+For [`generic-oidc`](#generic-oidc-receiver) receivers, the verified OIDC token
+claims are also available to the expression via the `claims` variable. This
+allows filtering resources based on the identity of the caller, for example:
+
+```yaml
+  resourceFilter: claims.repository == res.metadata.annotations['source-repository']
+```
+
+The `claims` variable is only declared for `generic-oidc` receivers; using it in
+the `resourceFilter` of any other Receiver type is rejected as an invalid CEL
+expression.
+
 ### Secret reference
 
 `.spec.secretRef.name` specifies a name reference to a Secret in the same

--- a/internal/controller/receiver_controller.go
+++ b/internal/controller/receiver_controller.go
@@ -212,7 +212,11 @@ func (r *ReceiverReconciler) reconcile(ctx context.Context, obj *apiv1.Receiver)
 	log := ctrl.LoggerFrom(ctx)
 
 	if filter := obj.Spec.ResourceFilter; filter != "" {
-		if err := server.ValidateResourceFilter(filter); err != nil {
+		var opts []server.ResourceFilterOption
+		if obj.Spec.Type == apiv1.GenericOIDCReceiver {
+			opts = append(opts, server.WithClaims())
+		}
+		if err := server.ValidateResourceFilter(filter, opts...); err != nil {
 			r.markTerminal(obj, log, meta.InvalidCELExpressionReason, err)
 			return ctrl.Result{}, nil
 		}

--- a/internal/server/receiver_handlers.go
+++ b/internal/server/receiver_handlers.go
@@ -114,7 +114,8 @@ func (s *ReceiverServer) handlePayload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.validate(ctx, receiver, r); err != nil {
+	result, err := s.validate(ctx, receiver, r)
+	if err != nil {
 		logger.Error(err, "unable to validate payload")
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -125,7 +126,7 @@ func (s *ReceiverServer) handlePayload(w http.ResponseWriter, r *http.Request) {
 		return &accept, nil
 	}
 	if receiver.Spec.ResourceFilter != "" {
-		resourceFilter, err = newResourceFilter(receiver.Spec.ResourceFilter, r)
+		resourceFilter, err = newResourceFilter(receiver.Spec.ResourceFilter, r, result)
 		if err != nil {
 			logger.Error(err, "unable to create resource filter")
 			w.WriteHeader(http.StatusInternalServerError)
@@ -214,14 +215,24 @@ func (s *ReceiverServer) notifyDynamicResources(ctx context.Context, logger logr
 	return nil
 }
 
-func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, r *http.Request) error {
+// validationResult carries data extracted while authenticating an incoming
+// webhook request that later steps need.
+type validationResult struct {
+	// claims holds the verified OIDC token claims for generic-oidc receivers,
+	// exposed to the Receiver's resourceFilter. It is nil for all other types.
+	claims map[string]any
+}
+
+// validate authenticates the incoming request against the Receiver's
+// configuration. It returns nil on failure and a non-nil result on success.
+func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, r *http.Request) (*validationResult, error) {
 	// Validate payload size before doing anything else in case we are being DDoSed.
 	b, err := io.ReadAll(io.LimitReader(r.Body, maxRequestSizeBytes+1))
 	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
+		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}
 	if len(b) > maxRequestSizeBytes {
-		return fmt.Errorf("request body exceeds the maximum size of %d bytes", maxRequestSizeBytes)
+		return nil, fmt.Errorf("request body exceeds the maximum size of %d bytes", maxRequestSizeBytes)
 	}
 	r.Body = io.NopCloser(bytes.NewReader(b))
 
@@ -233,7 +244,7 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 	if receiver.Spec.SecretRef != nil {
 		secret, err = s.secret(ctx, receiver)
 		if err != nil {
-			return fmt.Errorf("unable to read secret, error: %w", err)
+			return nil, fmt.Errorf("unable to read secret, error: %w", err)
 		}
 
 		secretName := types.NamespacedName{
@@ -242,7 +253,7 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 		}
 		tokenBytes, ok := secret.Data["token"]
 		if !ok {
-			return fmt.Errorf("invalid %q secret data: required field 'token'", secretName)
+			return nil, fmt.Errorf("invalid %q secret data: required field 'token'", secretName)
 		}
 		token = string(tokenBytes)
 	}
@@ -254,25 +265,29 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 
 	switch receiver.Spec.Type {
 	case apiv1.GenericReceiver:
-		return nil
+		return &validationResult{}, nil
 	case apiv1.GenericOIDCReceiver:
-		return s.validateGenericOIDC(ctx, receiver, r)
+		claims, err := s.validateGenericOIDC(ctx, receiver, r)
+		if err != nil {
+			return nil, err
+		}
+		return &validationResult{claims: claims}, nil
 	case apiv1.GenericHMACReceiver:
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
-			return fmt.Errorf("unable to read request body: %s", err)
+			return nil, fmt.Errorf("unable to read request body: %s", err)
 		}
 
 		err = github.ValidateSignature(r.Header.Get("X-Signature"), b, []byte(token))
 		if err != nil {
-			return fmt.Errorf("unable to validate HMAC signature: %s", err)
+			return nil, fmt.Errorf("unable to validate HMAC signature: %s", err)
 		}
 		r.Body = io.NopCloser(bytes.NewReader(b))
-		return nil
+		return &validationResult{}, nil
 	case apiv1.GitHubReceiver:
 		b, err := github.ValidatePayload(r, []byte(token))
 		if err != nil {
-			return fmt.Errorf("the GitHub signature header is invalid, err: %w", err)
+			return nil, fmt.Errorf("the GitHub signature header is invalid, err: %w", err)
 		}
 
 		event := github.WebHookType(r)
@@ -285,16 +300,16 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 				}
 			}
 			if !allowed {
-				return fmt.Errorf("the GitHub event %q is not authorised", event)
+				return nil, fmt.Errorf("the GitHub event %q is not authorised", event)
 			}
 		}
 
 		logger.Info(fmt.Sprintf("handling GitHub event: %s", event))
 		r.Body = io.NopCloser(bytes.NewReader(b))
-		return nil
+		return &validationResult{}, nil
 	case apiv1.GitLabReceiver:
 		if r.Header.Get("X-Gitlab-Token") != token {
-			return fmt.Errorf("the X-Gitlab-Token header value does not match the receiver token")
+			return nil, fmt.Errorf("the X-Gitlab-Token header value does not match the receiver token")
 		}
 
 		event := r.Header.Get("X-Gitlab-Event")
@@ -307,27 +322,27 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 				}
 			}
 			if !allowed {
-				return fmt.Errorf("the GitLab event %q is not authorised", event)
+				return nil, fmt.Errorf("the GitLab event %q is not authorised", event)
 			}
 		}
 
 		logger.Info(fmt.Sprintf("handling GitLab event: %s", event))
-		return nil
+		return &validationResult{}, nil
 	case apiv1.CDEventsReceiver:
 		event := r.Header.Get("Ce-Type")
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
-			return fmt.Errorf("unable to read CDEvent request body: %s", err)
+			return nil, fmt.Errorf("unable to read CDEvent request body: %s", err)
 		}
 
 		cdevent, err := cdevents04.NewFromJsonBytes(b)
 		if err != nil {
-			return fmt.Errorf("unable to validate CDEvent event: %s", err)
+			return nil, fmt.Errorf("unable to validate CDEvent event: %s", err)
 		}
 
 		err = cdevents.Validate(cdevent)
 		if err != nil {
-			return fmt.Errorf("unable to validate CDEvent event: %s", err)
+			return nil, fmt.Errorf("unable to validate CDEvent event: %s", err)
 		}
 
 		if len(receiver.Spec.Events) > 0 {
@@ -339,17 +354,17 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 				}
 			}
 			if !allowed {
-				return fmt.Errorf("the CDEvent %q is not authorised", event)
+				return nil, fmt.Errorf("the CDEvent %q is not authorised", event)
 			}
 		}
 
 		logger.Info(fmt.Sprintf("handling CDEvent: %s", event))
 		r.Body = io.NopCloser(bytes.NewReader(b))
-		return nil
+		return &validationResult{}, nil
 	case apiv1.BitbucketReceiver:
 		b, err := github.ValidatePayload(r, []byte(token))
 		if err != nil {
-			return fmt.Errorf("the Bitbucket server signature header is invalid, err: %w", err)
+			return nil, fmt.Errorf("the Bitbucket server signature header is invalid, err: %w", err)
 		}
 
 		event := r.Header.Get("X-Event-Key")
@@ -362,13 +377,13 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 				}
 			}
 			if !allowed {
-				return fmt.Errorf("the Bitbucket server event %q is not authorised", event)
+				return nil, fmt.Errorf("the Bitbucket server event %q is not authorised", event)
 			}
 		}
 
 		logger.Info(fmt.Sprintf("handling Bitbucket server event: %s", event))
 		r.Body = io.NopCloser(bytes.NewReader(b))
-		return nil
+		return &validationResult{}, nil
 	case apiv1.QuayReceiver:
 		type payload struct {
 			DockerUrl   string   `json:"docker_url"`
@@ -377,24 +392,24 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
-			return fmt.Errorf("unable to read request body: %s", err)
+			return nil, fmt.Errorf("unable to read request body: %s", err)
 		}
 		r.Body = io.NopCloser(bytes.NewReader(b))
 		var p payload
 		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
-			return fmt.Errorf("cannot decode Quay webhook payload: %w", err)
+			return nil, fmt.Errorf("cannot decode Quay webhook payload: %w", err)
 		}
 
 		logger.Info(fmt.Sprintf("handling Quay event from %s", p.DockerUrl))
 		r.Body = io.NopCloser(bytes.NewReader(b))
-		return nil
+		return &validationResult{}, nil
 	case apiv1.HarborReceiver:
 		if r.Header.Get("Authorization") != token {
-			return fmt.Errorf("the Harbor Authorization header value does not match the receiver token")
+			return nil, fmt.Errorf("the Harbor Authorization header value does not match the receiver token")
 		}
 
 		logger.Info("handling Harbor event")
-		return nil
+		return &validationResult{}, nil
 	case apiv1.DockerHubReceiver:
 		type payload struct {
 			PushData struct {
@@ -406,17 +421,17 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 		}
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
-			return fmt.Errorf("unable to read request body: %s", err)
+			return nil, fmt.Errorf("unable to read request body: %s", err)
 		}
 		r.Body = io.NopCloser(bytes.NewReader(b))
 		var p payload
 		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
-			return fmt.Errorf("cannot decode DockerHub webhook payload")
+			return nil, fmt.Errorf("cannot decode DockerHub webhook payload")
 		}
 
 		logger.Info(fmt.Sprintf("handling DockerHub event from %s for tag %s", p.Repository.URL, p.PushData.Tag))
 		r.Body = io.NopCloser(bytes.NewReader(b))
-		return nil
+		return &validationResult{}, nil
 	case apiv1.GCRReceiver:
 		type data struct {
 			Action string `json:"action"`
@@ -434,17 +449,17 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 		}
 
 		if secret == nil {
-			return fmt.Errorf("secretRef is required for GCR receivers")
+			return nil, fmt.Errorf("secretRef is required for GCR receivers")
 		}
 
 		expectedEmail := string(secret.Data["email"])
 		if expectedEmail == "" {
-			return fmt.Errorf("invalid secret data: required field 'email' for GCR receiver")
+			return nil, fmt.Errorf("invalid secret data: required field 'email' for GCR receiver")
 		}
 
 		expectedAudience := string(secret.Data["audience"])
 		if expectedAudience == "" {
-			return fmt.Errorf("invalid secret data: required field 'audience' for GCR receiver")
+			return nil, fmt.Errorf("invalid secret data: required field 'audience' for GCR receiver")
 		}
 
 		authenticate := authenticateGCRRequest
@@ -452,12 +467,12 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 			authenticate = s.gcrTokenValidator
 		}
 		if err := authenticate(ctx, r.Header.Get("Authorization"), expectedEmail, expectedAudience); err != nil {
-			return fmt.Errorf("cannot authenticate GCR request: %w", err)
+			return nil, fmt.Errorf("cannot authenticate GCR request: %w", err)
 		}
 
 		var p payload
 		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
-			return fmt.Errorf("cannot decode GCR webhook payload: %w", err)
+			return nil, fmt.Errorf("cannot decode GCR webhook payload: %w", err)
 		}
 		// The GCR payload is a Google PubSub event with the GCR event wrapped
 		// inside (in base64 JSON).
@@ -466,30 +481,30 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 		var d data
 		err = json.Unmarshal(raw, &d)
 		if err != nil {
-			return fmt.Errorf("cannot decode GCR webhook body: %w", err)
+			return nil, fmt.Errorf("cannot decode GCR webhook body: %w", err)
 		}
 
 		logger.Info(fmt.Sprintf("handling GCR event from %s for tag %s", d.Digest, d.Tag))
 		encodedPayload, err := json.Marshal(d)
 		if err != nil {
-			return fmt.Errorf("cannot decode GCR webhook body: %w", err)
+			return nil, fmt.Errorf("cannot decode GCR webhook body: %w", err)
 		}
 		// This only puts the unwrapped event into the payload.
 		r.Body = io.NopCloser(bytes.NewReader(encodedPayload))
-		return nil
+		return &validationResult{}, nil
 	case apiv1.NexusReceiver:
 		signature := r.Header.Get("X-Nexus-Webhook-Signature")
 		if len(signature) == 0 {
-			return fmt.Errorf("the Nexus signature is missing from header")
+			return nil, fmt.Errorf("the Nexus signature is missing from header")
 		}
 
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
-			return fmt.Errorf("cannot read Nexus payload. error: %w", err)
+			return nil, fmt.Errorf("cannot read Nexus payload. error: %w", err)
 		}
 
 		if !verifyHmacSignature([]byte(token), signature, b) {
-			return fmt.Errorf("invalid Nexus signature")
+			return nil, fmt.Errorf("invalid Nexus signature")
 		}
 		type payload struct {
 			Action         string `json:"action"`
@@ -497,12 +512,12 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 		}
 		var p payload
 		if err := json.Unmarshal(b, &p); err != nil {
-			return fmt.Errorf("cannot decode Nexus webhook payload: %w", err)
+			return nil, fmt.Errorf("cannot decode Nexus webhook payload: %w", err)
 		}
 
 		logger.Info(fmt.Sprintf("handling Nexus event from %s", p.RepositoryName))
 		r.Body = io.NopCloser(bytes.NewReader(b))
-		return nil
+		return &validationResult{}, nil
 	case apiv1.ACRReceiver:
 		type target struct {
 			Repository string `json:"repository"`
@@ -516,21 +531,21 @@ func (s *ReceiverServer) validate(ctx context.Context, receiver apiv1.Receiver, 
 
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
-			return fmt.Errorf("unable to read request body: %s", err)
+			return nil, fmt.Errorf("unable to read request body: %s", err)
 		}
 		r.Body = io.NopCloser(bytes.NewReader(b))
 
 		var p payload
 		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
-			return fmt.Errorf("cannot decode ACR webhook payload: %s", err)
+			return nil, fmt.Errorf("cannot decode ACR webhook payload: %s", err)
 		}
 
 		logger.Info(fmt.Sprintf("handling ACR event from %s for tag %s", p.Target.Repository, p.Target.Tag))
 		r.Body = io.NopCloser(bytes.NewReader(b))
-		return nil
+		return &validationResult{}, nil
 	}
 
-	return fmt.Errorf("recevier type %q not supported", receiver.Spec.Type)
+	return nil, fmt.Errorf("recevier type %q not supported", receiver.Spec.Type)
 }
 
 func (s *ReceiverServer) secret(ctx context.Context, receiver apiv1.Receiver) (*corev1.Secret, error) {

--- a/internal/server/receiver_oidc.go
+++ b/internal/server/receiver_oidc.go
@@ -31,25 +31,26 @@ import (
 
 // validateGenericOIDC verifies the bearer token of an incoming request against
 // one of the configured OIDC providers and evaluates the provider's CEL
-// variables and validations over the verified claims.
-func (s *ReceiverServer) validateGenericOIDC(ctx context.Context, receiver apiv1.Receiver, r *http.Request) error {
+// variables and validations over the verified claims. On success it returns the
+// verified claims so they can be exposed to the Receiver's resourceFilter.
+func (s *ReceiverServer) validateGenericOIDC(ctx context.Context, receiver apiv1.Receiver, r *http.Request) (map[string]any, error) {
 	if len(receiver.Spec.OIDCProviders) == 0 {
-		return fmt.Errorf("generic-oidc receiver has no oidcProviders configured")
+		return nil, fmt.Errorf("generic-oidc receiver has no oidcProviders configured")
 	}
 
 	bearer := r.Header.Get("Authorization")
 	const prefix = "Bearer "
 	if !strings.HasPrefix(bearer, prefix) {
-		return fmt.Errorf("the Authorization header is missing or malformed")
+		return nil, fmt.Errorf("the Authorization header is missing or malformed")
 	}
 	rawToken := strings.TrimSpace(bearer[len(prefix):])
 	if rawToken == "" {
-		return fmt.Errorf("the Authorization header is missing a bearer token")
+		return nil, fmt.Errorf("the Authorization header is missing a bearer token")
 	}
 
 	iss, err := unverifiedTokenIssuer(rawToken)
 	if err != nil {
-		return fmt.Errorf("failed to parse bearer token: %w", err)
+		return nil, fmt.Errorf("failed to parse bearer token: %w", err)
 	}
 
 	var provider *apiv1.OIDCProvider
@@ -60,34 +61,38 @@ func (s *ReceiverServer) validateGenericOIDC(ctx context.Context, receiver apiv1
 		}
 	}
 	if provider == nil {
-		return fmt.Errorf("no oidcProvider configured for issuer %q", iss)
+		return nil, fmt.Errorf("no oidcProvider configured for issuer %q", iss)
 	}
 
 	oidcProvider, err := oidc.NewProvider(ctx, provider.IssuerURL)
 	if err != nil {
-		return fmt.Errorf("failed to initialize OIDC provider for issuer %q: %w", provider.IssuerURL, err)
+		return nil, fmt.Errorf("failed to initialize OIDC provider for issuer %q: %w", provider.IssuerURL, err)
 	}
 	verifier := oidcProvider.Verifier(&oidc.Config{ClientID: provider.GetAudience()})
 
 	idToken, err := verifier.Verify(ctx, rawToken)
 	if err != nil {
-		return fmt.Errorf("failed to verify OIDC token: %w", err)
+		return nil, fmt.Errorf("failed to verify OIDC token: %w", err)
 	}
 
 	var claims map[string]any
 	if err := idToken.Claims(&claims); err != nil {
-		return fmt.Errorf("failed to extract OIDC token claims: %w", err)
+		return nil, fmt.Errorf("failed to extract OIDC token claims: %w", err)
 	}
 
 	processor, err := newOIDCClaimsProcessor(*provider)
 	if err != nil {
-		return fmt.Errorf("invalid oidcProvider configuration for issuer %q: %w", provider.IssuerURL, err)
+		return nil, fmt.Errorf("invalid oidcProvider configuration for issuer %q: %w", provider.IssuerURL, err)
 	}
 	if err := processor.Evaluate(ctx, claims); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	if claims == nil {
+		claims = map[string]any{}
+	}
+
+	return claims, nil
 }
 
 // unverifiedTokenIssuer extracts the 'iss' claim from a JWT without verifying

--- a/internal/server/receiver_oidc_test.go
+++ b/internal/server/receiver_oidc_test.go
@@ -175,11 +175,17 @@ func TestValidateGenericOIDC(t *testing.T) {
 		bearer      string
 		expectError bool
 		errContains string
+		wantClaims  map[string]any
 	}{
 		{
 			name:     "valid token passes validations",
 			receiver: newOIDCReceiver("ok", []apiv1.OIDCProvider{baseProvider}),
 			bearer:   "Bearer " + iss.sign(t, validClaims()),
+			wantClaims: map[string]any{
+				"sub":         "subject",
+				"repository":  "my-org/my-repo",
+				"environment": "production",
+			},
 		},
 		{
 			name:        "missing authorization header",
@@ -281,14 +287,21 @@ func TestValidateGenericOIDC(t *testing.T) {
 				req.Header.Set("Authorization", tt.bearer)
 			}
 
-			err := s.validateGenericOIDC(context.Background(), *tt.receiver, req)
+			claims, err := s.validateGenericOIDC(context.Background(), *tt.receiver, req)
 			if tt.expectError {
 				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(claims).To(gomega.BeNil())
 				if tt.errContains != "" {
 					g.Expect(err.Error()).To(gomega.ContainSubstring(tt.errContains))
 				}
 			} else {
 				g.Expect(err).NotTo(gomega.HaveOccurred(), "unexpected error: %v", err)
+				g.Expect(claims).NotTo(gomega.BeNil())
+				if tt.wantClaims != nil {
+					for k, v := range tt.wantClaims {
+						g.Expect(claims).To(gomega.HaveKeyWithValue(k, v))
+					}
+				}
 			}
 		})
 	}

--- a/internal/server/receiver_resource_filter.go
+++ b/internal/server/receiver_resource_filter.go
@@ -31,22 +31,62 @@ import (
 
 type resourceFilter func(context.Context, client.Object) (*bool, error)
 
+// ResourceFilterOption configures the CEL environment used to compile and
+// evaluate a Receiver resource filter expression.
+type ResourceFilterOption func(*resourceFilterOptions)
+
+type resourceFilterOptions struct {
+	withClaims bool
+}
+
+// WithClaims declares the claims variable in the filter CEL environment. It is
+// used by generic-oidc receivers to expose the verified OIDC token claims to
+// the expression.
+func WithClaims() ResourceFilterOption {
+	return func(o *resourceFilterOptions) {
+		o.withClaims = true
+	}
+}
+
 // ValidateResourceFilter accepts a CEL expression and will parse and check that
 // it's valid, if it's not valid an error is returned.
-func ValidateResourceFilter(s string) error {
-	_, err := newFilterExpression(s)
+func ValidateResourceFilter(s string, opts ...ResourceFilterOption) error {
+	_, err := newFilterExpression(s, opts...)
 	return err
 }
 
-func newFilterExpression(s string) (*cel.Expression, error) {
+func newFilterExpression(s string, opts ...ResourceFilterOption) (*cel.Expression, error) {
+	var o resourceFilterOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	vars := []string{"res", "req"}
+	if o.withClaims {
+		vars = append(vars, "claims")
+	}
+
 	return cel.NewExpression(s,
 		cel.WithCompile(),
 		cel.WithOutputType(types.BoolType),
-		cel.WithStructVariables("res", "req"))
+		cel.WithStructVariables(vars...))
 }
 
-func newResourceFilter(expr string, r *http.Request) (resourceFilter, error) {
-	celExpr, err := newFilterExpression(expr)
+// newResourceFilter compiles the CEL expression and returns a filter that
+// evaluates it against each resource. When the validation result carries OIDC
+// token claims (generic-oidc receivers), they are exposed as the claims variable.
+func newResourceFilter(expr string, r *http.Request, result *validationResult) (resourceFilter, error) {
+	var claims map[string]any
+	if result != nil {
+		claims = result.claims
+	}
+
+	var opts []ResourceFilterOption
+	if claims != nil {
+		opts = append(opts, WithClaims())
+	}
+
+	celExpr, err := newFilterExpression(expr, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -66,10 +106,15 @@ func newResourceFilter(expr string, r *http.Request) (resourceFilter, error) {
 			return nil, err
 		}
 
-		result, err := celExpr.EvaluateBoolean(ctx, map[string]any{
+		vars := map[string]any{
 			"res": res,
 			"req": req,
-		})
+		}
+		if claims != nil {
+			vars["claims"] = claims
+		}
+
+		result, err := celExpr.EvaluateBoolean(ctx, vars)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/receiver_resource_filter_test.go
+++ b/internal/server/receiver_resource_filter_test.go
@@ -68,10 +68,21 @@ func TestValidateCELExpressionInvalidExpressions(t *testing.T) {
 	}
 }
 
+func TestValidateCELExpressionClaims(t *testing.T) {
+	g := NewWithT(t)
+
+	// The claims variable is undeclared unless WithClaims is passed, mirroring
+	// that only generic-oidc receivers expose verified OIDC token claims.
+	g.Expect(ValidateResourceFilter(`claims.sub == 'test'`)).
+		To(MatchError(ContainSubstring("undeclared reference to 'claims'")))
+	g.Expect(ValidateResourceFilter(`claims.sub == 'test'`, WithClaims())).To(Succeed())
+}
+
 func TestCELEvaluation(t *testing.T) {
 	evaluationTests := []struct {
 		expression string
 		request    *http.Request
+		claims     map[string]any
 		resource   client.Object
 		wantResult bool
 	}{
@@ -92,6 +103,41 @@ func TestCELEvaluation(t *testing.T) {
 				},
 			},
 			wantResult: true,
+		},
+		{
+			expression: `res.metadata.name == 'test-resource' && claims.sub == 'system:serviceaccount:apps:deployer' && claims.repository == 'hello-world'`,
+			request:    testNewHTTPRequest(t, http.MethodPost, "/test", nil),
+			claims: map[string]any{
+				"sub":        "system:serviceaccount:apps:deployer",
+				"repository": "hello-world",
+			},
+			resource: &apiv1.Receiver{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       apiv1.ReceiverKind,
+					APIVersion: apiv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-resource",
+				},
+			},
+			wantResult: true,
+		},
+		{
+			expression: `claims.environment == 'production'`,
+			request:    testNewHTTPRequest(t, http.MethodPost, "/test", nil),
+			claims: map[string]any{
+				"environment": "staging",
+			},
+			resource: &apiv1.Receiver{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       apiv1.ReceiverKind,
+					APIVersion: apiv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-resource",
+				},
+			},
+			wantResult: false,
 		},
 		{
 			expression: `req.bool == true`,
@@ -132,7 +178,7 @@ func TestCELEvaluation(t *testing.T) {
 	for _, tt := range evaluationTests {
 		t.Run(tt.expression, func(t *testing.T) {
 			g := NewWithT(t)
-			resourceFilter, err := newResourceFilter(tt.expression, tt.request)
+			resourceFilter, err := newResourceFilter(tt.expression, tt.request, &validationResult{claims: tt.claims})
 			g.Expect(err).To(Succeed())
 
 			result, err := resourceFilter(context.Background(), tt.resource)


### PR DESCRIPTION
Follow-up for #1306

In my setup I have a single Receiver per namespace. In one of them (`flux-system`) I have two use cases for Receiver:

* An OCIRepository that is triggered by a GitHub Actions workflow in one repo
* A ResourceSetInputProvider that is triggered by a GitHub Actions workflow in another repo

I want to allow each repo to trigger only the resources they need to trigger. They can't trigger resources they don't relate to.

Currently, to make the above possible, I have split the Receiver in two. Each Receiver has a strict OIDC validation that allows the repo to trigger only the respective resource it relates to.

If the OIDC claims were injected into the `.spec.resourceFilter` context, the CEL expression would be more powerful, allowing me to keep a single Receiver per namespace like before (when I was using `generic-hmac`).