### PR TITLE
Add a fallback to the slack notification provider

### DIFF
--- a/internal/notifier/slack.go
+++ b/internal/notifier/slack.go
@@ -51,6 +51,7 @@ type SlackPayload struct {
 
 // SlackAttachment holds the markdown message body
 type SlackAttachment struct {
+	Fallback   string       `json:"fallback"`
 	Color      string       `json:"color"`
 	AuthorName string       `json:"author_name"`
 	Text       string       `json:"text"`
@@ -105,9 +106,11 @@ func (s *Slack) Post(ctx context.Context, event eventv1.Event) error {
 		sfields = append(sfields, SlackField{k, v, false})
 	}
 
+	author := fmt.Sprintf("%s/%s.%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.InvolvedObject.Namespace)
 	a := SlackAttachment{
+		Fallback:   fmt.Sprintf("%s: %s", author, strings.Split(event.Message, "\n")[0]),
 		Color:      color,
-		AuthorName: fmt.Sprintf("%s/%s.%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.InvolvedObject.Namespace),
+		AuthorName: author,
 		Text:       event.Message,
 		MrkdwnIn:   []string{"text"},
 		Fields:     sfields,


### PR DESCRIPTION
This PR adds a short "fallback" message consisting of the components which is used to form the `AuthorName` as well as the first line of `event.Message` which is used as the `Text`.

[Slack documentation](https://docs.slack.dev/tools/node-slack-sdk/reference/web-api/interfaces/MessageAttachment/#fallback) says that the `fallback` text is used in clients that don't show formatted text (e.g. mobile notifications). Keeping it to use the first line of `event.Message` should keep it short enough for mobile notifications and such..

In Mattermost, `fallback` is actually a requirement, see [Mattermost Message Attachment options](https://developers.mattermost.com/integrate/reference/message-attachments/#attachment-options). Various deployments are using the Slack notification provider for Mattermost notifications - we're one of them.