### PR TITLE
Add categories to notification CRDs

### DIFF
--- a/api/v1/receiver_types.go
+++ b/api/v1/receiver_types.go
@@ -251,6 +251,7 @@ func (in *Receiver) GetInterval() time.Duration {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all;fluxcd;fluxcd-notifications
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/api/v1beta3/alert_types.go
+++ b/api/v1beta3/alert_types.go
@@ -80,6 +80,7 @@ type AlertSpec struct {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all;fluxcd;fluxcd-notifications
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 
 // Alert is the Schema for the alerts API

--- a/api/v1beta3/provider_types.go
+++ b/api/v1beta3/provider_types.go
@@ -170,6 +170,7 @@ type ProviderSpec struct {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all;fluxcd;fluxcd-notifications
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 
 // Provider is the Schema for the providers API

--- a/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: notification.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-notifications
     kind: Alert
     listKind: AlertList
     plural: alerts

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: notification.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-notifications
     kind: Provider
     listKind: ProviderList
     plural: providers

--- a/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: notification.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-notifications
     kind: Receiver
     listKind: ReceiverList
     plural: receivers


### PR DESCRIPTION
This adds the standard Flux resource categories to every CRD in this
repository so users can list Flux resources with kubectl, for example:

```
kubectl get fluxcd          # all Flux resources
kubectl get fluxcd-notifications   # all resources in this category
kubectl get all             # now includes Flux resources
```

Each CRD gets exactly three categories:

```
all
fluxcd
fluxcd-notifications
```

The CRDs were regenerated with `make manifests`.

Part of fluxcd/flux2#5947
