### PR TITLE
feat(api): add CRD categories for Alert and Provider

### DIFF
--- a/api/v1beta3/alert_types.go
+++ b/api/v1beta3/alert_types.go
@@ -80,6 +80,7 @@ type AlertSpec struct {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all;fluxcd;fluxcd-notifications
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 
 // Alert is the Schema for the alerts API

--- a/api/v1beta3/provider_types.go
+++ b/api/v1beta3/provider_types.go
@@ -170,6 +170,7 @@ type ProviderSpec struct {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all;fluxcd;fluxcd-notifications
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 
 // Provider is the Schema for the providers API

--- a/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: notification.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-notifications
     kind: Alert
     listKind: AlertList
     plural: alerts

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: notification.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-notifications
     kind: Provider
     listKind: ProviderList
     plural: providers


### PR DESCRIPTION
## Summary

Part of fluxcd/flux2#5947.

Adds `categories: [all, fluxcd, fluxcd-notifications]` to the Alert and Provider storage-version CRDs so they can be listed with `kubectl get fluxcd` and `kubectl get fluxcd-notifications`.

## Testing

- `make manifests`
- Verified generated CRD YAML contains the expected categories