### PR TITLE
Retry object updates on conflict in receiver tests

### DIFF
--- a/internal/controller/receiver_controller_test.go
+++ b/internal/controller/receiver_controller_test.go
@@ -330,13 +330,16 @@ func TestReceiverReconciler_Reconcile(t *testing.T) {
 
 		g.Expect(k8sClient.Delete(context.Background(), secret)).To(Succeed())
 
-		g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR)).To(Succeed())
-
 		reconcileRequestAt := metav1.Now().String()
-		resultR.SetAnnotations(map[string]string{
-			meta.ReconcileRequestAnnotation: reconcileRequestAt,
-		})
-		g.Expect(k8sClient.Update(context.Background(), resultR)).To(Succeed())
+		g.Eventually(func() error {
+			if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR); err != nil {
+				return err
+			}
+			resultR.SetAnnotations(map[string]string{
+				meta.ReconcileRequestAnnotation: reconcileRequestAt,
+			})
+			return k8sClient.Update(context.Background(), resultR)
+		}, timeout, time.Second).Should(Succeed())
 
 		g.Eventually(func() bool {
 			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR)
@@ -377,13 +380,16 @@ func TestReceiverReconciler_Reconcile(t *testing.T) {
 	t.Run("handles reconcileAt", func(t *testing.T) {
 		g := NewWithT(t)
 
-		g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR)).To(Succeed())
-
 		reconcileRequestAt := metav1.Now().String()
-		resultR.SetAnnotations(map[string]string{
-			meta.ReconcileRequestAnnotation: reconcileRequestAt,
-		})
-		g.Expect(k8sClient.Update(context.Background(), resultR)).To(Succeed())
+		g.Eventually(func() error {
+			if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR); err != nil {
+				return err
+			}
+			resultR.SetAnnotations(map[string]string{
+				meta.ReconcileRequestAnnotation: reconcileRequestAt,
+			})
+			return k8sClient.Update(context.Background(), resultR)
+		}, timeout, time.Second).Should(Succeed())
 
 		g.Eventually(func() bool {
 			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR)
@@ -394,10 +400,13 @@ func TestReceiverReconciler_Reconcile(t *testing.T) {
 	t.Run("finalizes suspended object", func(t *testing.T) {
 		g := NewWithT(t)
 
-		g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR)).To(Succeed())
-
-		resultR.Spec.Suspend = true
-		g.Expect(k8sClient.Update(context.Background(), resultR)).To(Succeed())
+		g.Eventually(func() error {
+			if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR); err != nil {
+				return err
+			}
+			resultR.Spec.Suspend = true
+			return k8sClient.Update(context.Background(), resultR)
+		}, timeout, time.Second).Should(Succeed())
 
 		g.Eventually(func() bool {
 			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR)
@@ -506,10 +515,13 @@ func TestReceiverReconciler_EventHandler(t *testing.T) {
 	t.Run("doesn't update the URL on spec updates", func(t *testing.T) {
 		g := NewWithT(t)
 
-		g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR)).To(Succeed())
-
-		resultR.Spec.Events = []string{"ping", "push"}
-		g.Expect(k8sClient.Update(context.Background(), resultR)).To(Succeed())
+		g.Eventually(func() error {
+			if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR); err != nil {
+				return err
+			}
+			resultR.Spec.Events = []string{"ping", "push"}
+			return k8sClient.Update(context.Background(), resultR)
+		}, timeout, time.Second).Should(Succeed())
 
 		g.Eventually(func() bool {
 			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR)


### PR DESCRIPTION
Fixes #473

### Problem

Several receiver test steps mutate an object immediately after an `Eventually` block that keys off a condition. The reconciler's deferred patch (`patch.SerialPatcher`) commits its changes with multiple sequential API requests: the conditions patch first, then metadata/spec, then the remaining status fields (`observedGeneration`, `lastHandledReconcileAt`, `webhookPath`). The `Eventually` can therefore return as soon as the conditions patch lands, while the trailing status patch is still in flight. If that patch commits between the test's `Get` and `Update`, the `Update` fails with an optimistic concurrency conflict ("the object has been modified"), producing the intermittent patch errors described in the issue.

### Changes

Converted the four remaining plain `Get` + mutate + `Update` sequences in `internal/controller/receiver_controller_test.go` to the read-modify-write retry idiom already used in other Flux controllers (e.g. kustomize-controller):

```go
g.Eventually(func() error {
    if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(receiver), resultR); err != nil {
        return err
    }
    resultR.Spec.Suspend = true
    return k8sClient.Update(context.Background(), resultR)
}, timeout, time.Second).Should(Succeed())
```

Sites changed:

- `TestReceiverReconciler_Reconcile` / "fails with secret not found error"
- `TestReceiverReconciler_Reconcile` / "handles reconcileAt"
- `TestReceiverReconciler_Reconcile` / "finalizes suspended object"
- `TestReceiverReconciler_EventHandler` / "doesn't update the URL on spec updates"

Audit of the remaining mutation sites in the test suite:

- The raw `client.RawPatch(types.MergePatchType, ...)` calls in the receiver tests do not send a `resourceVersion` and cannot conflict — this is the workaround the issue refers to as the "other option".
- The alert and provider tests read the object via `Eventually`/`Get` before patching, and `patch.Helper` issues its spec/metadata patch without an optimistic lock, so they cannot fail with conflict errors either.

No controller code is changed.

### Testing

```
KUBEBUILDER_ASSETS=... go test ./internal/controller/ -run 'TestReceiverReconciler' -v   # PASS
KUBEBUILDER_ASSETS=... go test ./internal/controller/                                   # ok (all package tests)
KUBEBUILDER_ASSETS=... go test ./internal/controller/ -run 'TestReceiverReconciler_Reconcile' -count=5  # ok
go vet ./internal/controller/ && gofmt -l internal/controller/                          # clean
```
