### PR TITLE
test: cover 2xx webhook responses including 204

### DIFF
--- a/internal/notifier/client.go
+++ b/internal/notifier/client.go
@@ -43,7 +43,7 @@ type postOption func(*postOptions)
 
 func postMessage(ctx context.Context, address string, payload any, opts ...postOption) error {
 	options := &postOptions{
-		// Default validateResponse function verifies that the response status code is 200, 202 or 201.
+		// Default validateResponse accepts any 2xx status (including 204 No Content).
 		responseValidator: func(resp *http.Response) error {
 			s := resp.StatusCode
 			if 200 <= s && s < 300 {

--- a/internal/notifier/client_test.go
+++ b/internal/notifier/client_test.go
@@ -54,6 +54,39 @@ func Test_postMessage(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 }
 
+func Test_postMessage_accepts2xxStatusCodes(t *testing.T) {
+	for _, code := range []int{
+		http.StatusOK,
+		http.StatusCreated,
+		http.StatusAccepted,
+		http.StatusNoContent,
+	} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			g := NewWithT(t)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer ts.Close()
+
+			err := postMessage(context.Background(), ts.URL, map[string]string{"status": "success"})
+			g.Expect(err).ToNot(HaveOccurred())
+		})
+	}
+
+	t.Run(http.StatusText(http.StatusBadRequest), func(t *testing.T) {
+		g := NewWithT(t)
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("nope"))
+		}))
+		defer ts.Close()
+
+		err := postMessage(context.Background(), ts.URL, map[string]string{"status": "success"})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("request failed with status code 400"))
+	})
+}
+
 func Test_postMessage_timeout(t *testing.T) {
 	g := NewWithT(t)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- The default `postMessage` response validator already accepts any HTTP 2xx status (`200 <= s < 300`), including `204 No Content`.
- The in-code comment still said only 200/201/202, which matches the stale claim in #441.
- Add regression tests for 200/201/202/204 success and 400 failure, and update the comment.

Fixes #441

## Test plan
- [x] `go test -count=1 -run Test_postMessage_accepts2xxStatusCodes ./internal/notifier/`
- [x] Existing `Test_postMessage` still passes
