### PR TITLE
Change incident.io provider type

### DIFF
--- a/api/v1beta3/provider_types.go
+++ b/api/v1beta3/provider_types.go
@@ -58,14 +58,14 @@ const (
 	ZulipProvider                     string = "zulip"
 	OTELProvider                      string = "otel"
 	ZoomProvider                      string = "zoom"
-	IncidentioProvider                string = "incidentio"
+	IncidentioProvider                string = "incident.io"
 )
 
 // ProviderSpec defines the desired state of the Provider.
 // +kubebuilder:validation:XValidation:rule="self.type == 'github' || self.type == 'gitlab' || self.type == 'gitea' || self.type == 'bitbucketserver' || self.type == 'bitbucket' || self.type == 'azuredevops' || !has(self.commitStatusExpr)", message="spec.commitStatusExpr is only supported for the 'github', 'gitlab', 'gitea', 'bitbucketserver', 'bitbucket', 'azuredevops' provider types"
 type ProviderSpec struct {
 	// Type specifies which Provider implementation to use.
-	// +kubebuilder:validation:Enum=slack;discord;msteams;rocket;generic;generic-hmac;github;gitlab;gitea;giteapullrequestcomment;bitbucketserver;bitbucket;azuredevops;googlechat;googlepubsub;webex;sentry;azureeventhub;telegram;lark;matrix;opsgenie;alertmanager;grafana;githubdispatch;githubpullrequestcomment;gitlabmergerequestcomment;pagerduty;datadog;nats;zulip;otel;zoom;incidentio
+	// +kubebuilder:validation:Enum=slack;discord;msteams;rocket;generic;generic-hmac;github;gitlab;gitea;giteapullrequestcomment;bitbucketserver;bitbucket;azuredevops;googlechat;googlepubsub;webex;sentry;azureeventhub;telegram;lark;matrix;opsgenie;alertmanager;grafana;githubdispatch;githubpullrequestcomment;gitlabmergerequestcomment;pagerduty;datadog;nats;zulip;otel;zoom;incident.io
 	// +required
 	Type string `json:"type"`
 

--- a/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
+++ b/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
@@ -187,7 +187,7 @@ spec:
                 - zulip
                 - otel
                 - zoom
-                - incidentio
+                - incident.io
                 type: string
               username:
                 description: Username specifies the name under which events are posted.

--- a/docs/spec/v1beta3/providers.md
+++ b/docs/spec/v1beta3/providers.md
@@ -96,7 +96,7 @@ The supported alerting providers are:
 | [Google Chat](#google-chat)                             | `googlechat`     |
 | [Google Pub/Sub](#google-pubsub)                        | `googlepubsub`   |
 | [Grafana](#grafana)                                     | `grafana`        |
-| [incident.io](#incidentio)                              | `incidentio`     |
+| [incident.io](#incidentio)                              | `incident.io`    |
 | [Lark](#lark)                                           | `lark`           |
 | [Matrix](#matrix)                                       | `matrix`         |
 | [Microsoft Teams](#microsoft-teams)                     | `msteams`        |
@@ -1362,7 +1362,7 @@ stringData:
 
 ##### incident.io
 
-When `.spec.type` is set to `incidentio`, the controller will send a payload for
+When `.spec.type` is set to `incident.io`, the controller will send a payload for
 an [Event](events.md#event-structure) to the provided incident.io
 [HTTP alert source](https://docs.incident.io/alerts/custom-http-sources) [Address](#address).
 
@@ -1394,7 +1394,7 @@ To configure a Provider for incident.io, create an
 [HTTP alert source](https://docs.incident.io/alerts/custom-http-sources) in the
 incident.io dashboard to obtain the endpoint URL and the API token, then create
 a Secret with [the `address`](#address-example) set to the endpoint URL,
-[the `token`](#token-example) set to the API token, and an `incidentio`
+[the `token`](#token-example) set to the API token, and an `incident.io`
 Provider with a [Secret reference](#secret-reference).
 
 ```yaml
@@ -1405,7 +1405,7 @@ metadata:
   name: incidentio
   namespace: default
 spec:
-  type: incidentio
+  type: incident.io
   secretRef:
     name: incidentio-alert-source
 ---

--- a/internal/controller/provider_controller_test.go
+++ b/internal/controller/provider_controller_test.go
@@ -134,6 +134,10 @@ func TestProviderReconciler_APIServerValidation(t *testing.T) {
 			providerType:     "github",
 			commitStatusExpr: "",
 		},
+		{
+			name:         "incident.io provider type can create providers",
+			providerType: apiv1beta3.IncidentioProvider,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This updates the incident.io Provider type value from `incidentio` to `incident.io` so the enum looks better in YAML.

Follow-up for  #1353